### PR TITLE
refactor: filter 컴포넌트 재사용성을 위한 기존의 filterList Props로 변경

### DIFF
--- a/src/components/Category&Filter/Filter/Filter.tsx
+++ b/src/components/Category&Filter/Filter/Filter.tsx
@@ -6,7 +6,10 @@ import FilterList from './FilterList';
 
 const cn = classNames.bind(styles);
 
-export default function Filter() {
+interface FilterProps {
+  filterList: { element: string; name: string; status: string }[];
+}
+export default function Filter({ filterList }: FilterProps) {
   const [isOpen, setIsOpen] = useState(false);
   const [selectedItem, setSelectedItem] = useState('필터');
 
@@ -20,7 +23,7 @@ export default function Filter() {
         <span className={cn('text')}>{selectedItem}</span>
         <ArrowDown fill={'#0B3B2D'} />
       </div>
-      {isOpen ? <FilterList setIsOpen={setIsOpen} setSelectedItem={setSelectedItem} /> : <></>}
+      {isOpen ? <FilterList filterList={filterList} setIsOpen={setIsOpen} setSelectedItem={setSelectedItem} /> : <></>}
     </div>
   );
 }

--- a/src/components/Category&Filter/Filter/FilterList.tsx
+++ b/src/components/Category&Filter/Filter/FilterList.tsx
@@ -5,18 +5,15 @@ import React, { useEffect, useRef } from 'react';
 const cn = classNames.bind(styles);
 
 interface filterListProps {
+  filterList: { element: string; name: string; status: string }[];
   setIsOpen: React.Dispatch<React.SetStateAction<boolean>>;
   setSelectedItem: React.Dispatch<React.SetStateAction<string>>;
 }
-export default function FilterList({ setIsOpen, setSelectedItem }: filterListProps) {
-  const filterList = ['많은 리뷰 순', '낮은 가격 순', '높은 가격 순', '최신 순'];
+export default function FilterList({ filterList, setIsOpen, setSelectedItem }: filterListProps) {
   const filterRef = useRef<HTMLDivElement>(null);
 
   const handleItemClick = (index: number) => {
-    if (index === 0) setSelectedItem('리뷰');
-    else if (index === 1 || index === 2) setSelectedItem('가격');
-    else setSelectedItem('최신');
-
+    setSelectedItem(filterList[index].name);
     setIsOpen(false);
   };
 
@@ -35,8 +32,8 @@ export default function FilterList({ setIsOpen, setSelectedItem }: filterListPro
   return (
     <div ref={filterRef} className={cn('dropdown')}>
       {filterList.map((item, index) => (
-        <div key={`${index} ${item}`} className={cn('item')} onClick={() => handleItemClick(index)}>
-          {item}
+        <div key={`${index} ${item.element}`} className={cn('item')} onClick={() => handleItemClick(index)}>
+          {item.element}
         </div>
       ))}
     </div>


### PR DESCRIPTION
## What is the PR? 🔍

- filter 컴포넌트 재사용성을 위한 기존의 filterList Props로 변경

## Changes 📝
사용 방법은 다음과 같습니다
```typescript
import Filter from '@/components/Category&Filter/Filter/Filter';

export default function Home() {
  // status는 클릭 후 api 호출 파라미터 사용 목적으로 추가했습니다.
  const filterList01 = [
    { element: '많은 리뷰 순', name: '리뷰', status: 'most_reviewed' },
    { element: '낮은 가격 순', name: '가격', status: 'price_asc' },
    { element: '높은 가격 순', name: '가격', status: 'price_desc' },
    { element: '최신 순', name: '최신', status: 'latest' },
  ];
  const filterList02 = [
    { element: '예약 신청', name: '신청', status: 'pending' },
    { element: '예약 취소', name: '취소', status: 'canceled' },
    { element: '예약 승인', name: '승인', status: 'confirmed' },
    { element: '예약 거절', name: '거절', status: 'declined' },
    { element: '체험 완료', name: '완료', status: 'completed' },
  ];
  return (
    <>
      // 이전의 사용방식
      <Filter />
      // 변경된 사용방식
      <Filter filterList={filterList02} />
    </>
  );
}

```

## Screenshot 📷

| 기능 |          스크린샷           |
| :--: | :-------------------------: |
| element  | ![image](https://github.com/sprint4-16/global-nomad/assets/155031984/42bb8a44-b429-4cdd-87aa-89d4477c4713) |
| name | ![image](https://github.com/sprint4-16/global-nomad/assets/155031984/19604c23-167e-44ed-afe3-d57cb79d13b5) |

## To Reviewers 🙏


## Related Issues 💭

- Resolved: #56 
