### PR TITLE
fix: 폰트 에러 수정

### DIFF
--- a/src/styles/_font.scss
+++ b/src/styles/_font.scss
@@ -7,7 +7,8 @@
 
 @font-face {
   font-family: 'Spoqa-Han-Sans-Neo';
-  src: url('//spoqa.github.io/spoqa-han-sans/css/SpoqaHanSansNeo.css') format('woff');
+  src: url('https://fastly.jsdelivr.net/gh/projectnoonnu/noonfonts_2108@1.1/SpoqaHanSansNeo-Regular.woff')
+    format('woff');
   font-weight: 400;
   font-style: normal;
 }
@@ -22,7 +23,7 @@
 
 @font-face {
   font-family: 'Inter';
-  src: url('https://fonts.googleapis.com/css2?family=Inter:wght@100..400&display=swap') format('woff');
+  src: url('https://fonts.googleapis.com/css2?family=Inter&display=swap') format('font-woff2');
   font-weight: 400;
   font-style: normal;
 }

--- a/src/styles/_font.scss
+++ b/src/styles/_font.scss
@@ -1,6 +1,7 @@
 @font-face {
   font-family: 'Pretendard';
-  src: url('https://fastly.jsdelivr.net/gh/Project-Noonnu/noonfonts_2107@1.1/Pretendard-Regular.woff') format('woff');
+  src: url('https://fastly.jsdelivr.net/gh/Project-Noonnu/noonfonts_2107@1.1/Pretendard-Regular.woff')
+    format('font-woff2');
   font-weight: 400;
   font-style: normal;
 }
@@ -8,7 +9,7 @@
 @font-face {
   font-family: 'Spoqa-Han-Sans-Neo';
   src: url('https://fastly.jsdelivr.net/gh/projectnoonnu/noonfonts_2108@1.1/SpoqaHanSansNeo-Regular.woff')
-    format('woff');
+    format('font-woff2');
   font-weight: 400;
   font-style: normal;
 }
@@ -16,7 +17,7 @@
 @font-face {
   font-family: 'Open-Sans';
   src: url('https://fonts.googleapis.com/css2?family=Open+Sans:ital,wght@0,300..800;1,300..800&display=swap')
-    format('woff');
+    format('font-woff2');
   font-weight: 400;
   font-style: normal;
 }


### PR DESCRIPTION
## What is the PR? 🔍

<!-- 아래 리스트를 지우고, 작업하게 된 배경을 적어주세요. -->

- 동현님이 미팅 시간이 이야기를 해주시니까 제가 너무 문제를 대충 넘어간 것 같다는 생각이 들어서 뭐가 원인인지 확인해봤습니다.
- 문제가 발생한 코드는 스푸카 한 산스 네오 폰트와 inter폰트를 불러오는 코드였는데 링크와 포맷의 문제가 있었습니다.

https://spoqa.github.io/spoqa-han-sans/
스푸카 한 산스 네오는 위의 공식 사이트에서 준 링크를 사용했는데, 알고보니까 불러오는 속도가 느린 샘플 버전인 것 같더라구요.
다른사이트에서 배포한 링크는 에러가 없길래 그걸 사용했습니다.

그리고 inter 폰트를 사용할 때 나오는 에러 메시지는 구글링 해본 결과 아래와 같은 결과가 나왔습니다.
https://velog.io/@bunny/Failed-to-decode-downloaded-font


woff는 웹폰트 형식을 부르는 명칭인데, WOFF2와 font-woff2는 명칭의 차이만 있을 뿐 둘 다 같은 거라고 하네요.
그런데 inter 폰트에서만 font-woff를 사용해야지만 에러가 발생하지 않았어요. 정확한 원인은 검색해도 잘 안나오네요

찾아보다 보니 woff 보다 woff2가 더 압축률이 좋다고 해서 다른 폰트도 전부 woff2로 변경했습니다.


## Changes 📝

<!-- 작업 내용 및 덧붙이고 싶은 내용이 있다면! -->

코드 링크 수정 및 포맷 형식 수정

## Screenshot 📷

<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->

| 기능 |          스크린샷           |
| :--: | :-------------------------: |
| GIF  | <img src = "" width ="250"> |

## To Reviewers 🙏

<!-- 리뷰어에게 주목했으면 하는 점 or 바라는 점을 적어주세요. -->

## Related Issues 💭

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. 수고했습니다~* -->

- Resolved: #73
