### PR TITLE
[feat] 예약 현황 페이지 api 데이터 불러오기

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -378,9 +378,9 @@
       }
     },
     "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.24.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.24.5.tgz",
-      "integrity": "sha512-xjNLDopRzW2o6ba0gKbkZq5YWEBaK3PCyTOY1K2P/O07LGMhMqlMXPxwN4S5/RhWuCobT8z0jrlKGlYmeR1OhQ==",
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.24.7.tgz",
+      "integrity": "sha512-Rq76wjt7yz9AAc1KnlRKNAi/dMSVWgDRx43FHoJEbcYU6xOWaE2dVPwcdTukJrjxS65GITyfbvEYHvkirZ6uEg==",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -467,9 +467,9 @@
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.23.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.23.5.tgz",
-      "integrity": "sha512-85ttAOMLsr53VgXkTbkx8oA6YTfT4q7/HzXSLEYmjcSTJPMPQtvq1BD79Byep5xMUYbGRzEpDsjUf3dyp54IKw==",
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.24.7.tgz",
+      "integrity": "sha512-yy1/KvjhV/ZCL+SM7hBrvnZJ3ZuT9OuZgIJAGpPEToANvc3iM6iDvBnRjtElWibHU6n8/LPR/EjX9EtIEYO3pw==",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -731,12 +731,12 @@
       }
     },
     "node_modules/@babel/plugin-syntax-flow": {
-      "version": "7.24.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.24.1.tgz",
-      "integrity": "sha512-sxi2kLTI5DeW5vDtMUsk4mTPwvlUDbjOnoWayhynCwrw4QXRld4QEYwqzY8JmQXaJUtgUuCIurtSRH5sn4c7mA==",
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.24.7.tgz",
+      "integrity": "sha512-9G8GYT/dxn/D1IIKOUBmGX0mnmj46mGH9NnZyJLwtCpgh5f7D2VbuKodb+2s9m1Yavh1s7ASQN8lf0eqrb1LTw==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.24.0"
+        "@babel/helper-plugin-utils": "^7.24.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1171,13 +1171,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-flow-strip-types": {
-      "version": "7.24.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.24.1.tgz",
-      "integrity": "sha512-iIYPIWt3dUmUKKE10s3W+jsQ3icFkw0JyRVyY1B7G4yK/nngAOHLVx8xlhA6b/Jzl/Y0nis8gjqhqKtRDQqHWQ==",
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.24.7.tgz",
+      "integrity": "sha512-cjRKJ7FobOH2eakx7Ja+KpJRj8+y+/SiB3ooYm/n2UJfxu0oEaOoxOinitkJcPqv9KxS0kxTGPUaR7L2XcXDXA==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.24.0",
-        "@babel/plugin-syntax-flow": "^7.24.1"
+        "@babel/helper-plugin-utils": "^7.24.7",
+        "@babel/plugin-syntax-flow": "^7.24.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1903,14 +1903,14 @@
       }
     },
     "node_modules/@babel/preset-flow": {
-      "version": "7.24.1",
-      "resolved": "https://registry.npmjs.org/@babel/preset-flow/-/preset-flow-7.24.1.tgz",
-      "integrity": "sha512-sWCV2G9pcqZf+JHyv/RyqEIpFypxdCSxWIxQjpdaQxenNog7cN1pr76hg8u0Fz8Qgg0H4ETkGcJnXL8d4j0PPA==",
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/@babel/preset-flow/-/preset-flow-7.24.7.tgz",
+      "integrity": "sha512-NL3Lo0NorCU607zU3NwRyJbpaB6E3t0xtd3LfAQKDfkeX4/ggcDXvkmkW42QWT5owUeW/jAe4hn+2qvkV1IbfQ==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.24.0",
-        "@babel/helper-validator-option": "^7.23.5",
-        "@babel/plugin-transform-flow-strip-types": "^7.24.1"
+        "@babel/helper-plugin-utils": "^7.24.7",
+        "@babel/helper-validator-option": "^7.24.7",
+        "@babel/plugin-transform-flow-strip-types": "^7.24.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1970,9 +1970,9 @@
       }
     },
     "node_modules/@babel/register": {
-      "version": "7.23.7",
-      "resolved": "https://registry.npmjs.org/@babel/register/-/register-7.23.7.tgz",
-      "integrity": "sha512-EjJeB6+kvpk+Y5DAkEAmbOBEFkh9OASx0huoEkqYTFxAZHzOAX2Oh5uwAUuL2rUddqfM0SA+KPXV2TbzoZ2kvQ==",
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/@babel/register/-/register-7.24.6.tgz",
+      "integrity": "sha512-WSuFCc2wCqMeXkz/i3yfAAsxwWflEgbVkZzivgAmXl/MxrXeoYFZOOPllbC8R8WTF7u61wSRQtDVZ1879cdu6w==",
       "dev": true,
       "dependencies": {
         "clone-deep": "^4.0.1",
@@ -3908,15 +3908,15 @@
       }
     },
     "node_modules/@storybook/builder-manager": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/@storybook/builder-manager/-/builder-manager-8.1.1.tgz",
-      "integrity": "sha512-WKpeDCtsmsesQYYYcXlCP17U1wdMGv6LnRY9BetKYbUPSHJo4eUBH8NmfW/ZjogczaUDw9sml6Sq5jIT35+Yuw==",
+      "version": "8.1.6",
+      "resolved": "https://registry.npmjs.org/@storybook/builder-manager/-/builder-manager-8.1.6.tgz",
+      "integrity": "sha512-Y5d+dikKnUuCYyh4VLEF6A+AbWughEgtipVkDKOddSTzn04trClIOKqfhQqEUObydCpgvvfdjGXJa/zDRV/UQA==",
       "dev": true,
       "dependencies": {
         "@fal-works/esbuild-plugin-global-externals": "^2.1.2",
-        "@storybook/core-common": "8.1.1",
-        "@storybook/manager": "8.1.1",
-        "@storybook/node-logger": "8.1.1",
+        "@storybook/core-common": "8.1.6",
+        "@storybook/manager": "8.1.6",
+        "@storybook/node-logger": "8.1.6",
         "@types/ejs": "^3.1.1",
         "@yarnpkg/esbuild-plugin-pnp": "^3.0.0-rc.10",
         "browser-assert": "^1.2.1",
@@ -3931,6 +3931,247 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/builder-manager/node_modules/@storybook/channels": {
+      "version": "8.1.6",
+      "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-8.1.6.tgz",
+      "integrity": "sha512-CzDnP6qfI8OC8pGUk+wPUzLPYcKhX8XbriF2gBtwl6qVM8YfkHP2mLTiDYDwBIi0rLuUbSm/SpILXQ/ouOHOGw==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/client-logger": "8.1.6",
+        "@storybook/core-events": "8.1.6",
+        "@storybook/global": "^5.0.0",
+        "telejson": "^7.2.0",
+        "tiny-invariant": "^1.3.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/builder-manager/node_modules/@storybook/client-logger": {
+      "version": "8.1.6",
+      "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-8.1.6.tgz",
+      "integrity": "sha512-QfSoUxS1rmrBzO7o99og9g+Gkm7sTmU5ZOpTkjszjlRqfV6/77eUnUOzUikej4LqPLmlJV5fqGuvoP0aNVksDw==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/global": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/builder-manager/node_modules/@storybook/core-common": {
+      "version": "8.1.6",
+      "resolved": "https://registry.npmjs.org/@storybook/core-common/-/core-common-8.1.6.tgz",
+      "integrity": "sha512-OTlfJFaTOB588ibXrrFm0TAXam6E5xV1VXSjNXL+fIifx8Kjln2HNSy1JKjvcblQneYiV4J1xPCVnAIe0EGHDg==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/core-events": "8.1.6",
+        "@storybook/csf-tools": "8.1.6",
+        "@storybook/node-logger": "8.1.6",
+        "@storybook/types": "8.1.6",
+        "@yarnpkg/fslib": "2.10.3",
+        "@yarnpkg/libzip": "2.3.0",
+        "chalk": "^4.1.0",
+        "cross-spawn": "^7.0.3",
+        "esbuild": "^0.18.0 || ^0.19.0 || ^0.20.0",
+        "esbuild-register": "^3.5.0",
+        "execa": "^5.0.0",
+        "file-system-cache": "2.3.0",
+        "find-cache-dir": "^3.0.0",
+        "find-up": "^5.0.0",
+        "fs-extra": "^11.1.0",
+        "glob": "^10.0.0",
+        "handlebars": "^4.7.7",
+        "lazy-universal-dotenv": "^4.0.0",
+        "node-fetch": "^2.0.0",
+        "picomatch": "^2.3.0",
+        "pkg-dir": "^5.0.0",
+        "prettier-fallback": "npm:prettier@^3",
+        "pretty-hrtime": "^1.0.3",
+        "resolve-from": "^5.0.0",
+        "semver": "^7.3.7",
+        "tempy": "^3.1.0",
+        "tiny-invariant": "^1.3.1",
+        "ts-dedent": "^2.0.0",
+        "util": "^0.12.4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "prettier": "^2 || ^3"
+      },
+      "peerDependenciesMeta": {
+        "prettier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@storybook/builder-manager/node_modules/@storybook/core-events": {
+      "version": "8.1.6",
+      "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-8.1.6.tgz",
+      "integrity": "sha512-DaIVe4TUp/7uQdSJYGmJv9S/S364tSgZ3S3dZ1vsf1rgoUbCp5kTBtcd/fcqgukMPREgCgO9oDhmemI3SLAqzw==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/csf": "^0.1.7",
+        "ts-dedent": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/builder-manager/node_modules/@storybook/csf-tools": {
+      "version": "8.1.6",
+      "resolved": "https://registry.npmjs.org/@storybook/csf-tools/-/csf-tools-8.1.6.tgz",
+      "integrity": "sha512-jrKfHFNhiLBhWWW4/fm2wgKEVg55e6QuYUHY16KGd7PdPuzm+2Pt7jIl5V9yIj6a59YbjeMpT6jWPKbFx2TuCw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/generator": "^7.24.4",
+        "@babel/parser": "^7.24.4",
+        "@babel/traverse": "^7.24.1",
+        "@babel/types": "^7.24.0",
+        "@storybook/csf": "^0.1.7",
+        "@storybook/types": "8.1.6",
+        "fs-extra": "^11.1.0",
+        "recast": "^0.23.5",
+        "ts-dedent": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/builder-manager/node_modules/@storybook/node-logger": {
+      "version": "8.1.6",
+      "resolved": "https://registry.npmjs.org/@storybook/node-logger/-/node-logger-8.1.6.tgz",
+      "integrity": "sha512-IZEiTLFHu8Oom/vdEGpisSw5CfU+cw6/fTaX1P3EVClFOWVuy8/3X5MPu4wJH3jPym6E2DBduIUFeRsiuq61gA==",
+      "dev": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/builder-manager/node_modules/@storybook/types": {
+      "version": "8.1.6",
+      "resolved": "https://registry.npmjs.org/@storybook/types/-/types-8.1.6.tgz",
+      "integrity": "sha512-cWpS9+x1pxCO39spR8QmumMK2ub2p5cvMtrRvWaIjBFPbCwm2CvjBXFWIra2veBCZTxUKJ9VWxvi7pzRHjN/nw==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/channels": "8.1.6",
+        "@types/express": "^4.7.0",
+        "file-system-cache": "2.3.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/builder-manager/node_modules/crypto-random-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-4.0.0.tgz",
+      "integrity": "sha512-x8dy3RnvYdlUcPOjkEHqozhiwzKNSq7GcPuXFbnyMOCHxX8V3OgIg/pYuabl2sbUPfIJaeAQB7PMOK8DFIdoRA==",
+      "dev": true,
+      "dependencies": {
+        "type-fest": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@storybook/builder-manager/node_modules/crypto-random-string/node_modules/type-fest": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
+      "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@storybook/builder-manager/node_modules/is-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+      "dev": true,
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@storybook/builder-manager/node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@storybook/builder-manager/node_modules/temp-dir": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-3.0.0.tgz",
+      "integrity": "sha512-nHc6S/bwIilKHNRgK/3jlhDoIHcp45YgyiwcAk46Tr0LfEqGBVpmiAyuiuxeVE44m3mXnEeVhaipLOEWmH+Njw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.16"
+      }
+    },
+    "node_modules/@storybook/builder-manager/node_modules/tempy": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tempy/-/tempy-3.1.0.tgz",
+      "integrity": "sha512-7jDLIdD2Zp0bDe5r3D2qtkd1QOCacylBuL7oa4udvN6v2pqr4+LcCr67C8DR1zkpaZ8XosF5m1yQSabKAW6f2g==",
+      "dev": true,
+      "dependencies": {
+        "is-stream": "^3.0.0",
+        "temp-dir": "^3.0.0",
+        "type-fest": "^2.12.2",
+        "unique-string": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@storybook/builder-manager/node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@storybook/builder-manager/node_modules/unique-string": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-3.0.0.tgz",
+      "integrity": "sha512-VGXBUVwxKMBUznyffQweQABPRRW1vHZAbadFZud4pLFAqRGvv/96vafgjWFqzourzr8YonlQiPgH0YCJfawoGQ==",
+      "dev": true,
+      "dependencies": {
+        "crypto-random-string": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@storybook/builder-webpack5": {
@@ -4011,22 +4252,22 @@
       }
     },
     "node_modules/@storybook/cli": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/@storybook/cli/-/cli-8.1.1.tgz",
-      "integrity": "sha512-ajLLIQnHjXpzUhYJ51b0eL/3uNuOjkbcx/B8HbgSbArBy7QvB9sX44wPJZYjL3GASYaZAppWixS2r36O/3yu+w==",
+      "version": "8.1.6",
+      "resolved": "https://registry.npmjs.org/@storybook/cli/-/cli-8.1.6.tgz",
+      "integrity": "sha512-xsFdBoAbo+2h/UCWuVXiH4Tu49iQ6d+3R1J8F2n4N6rAKxMqAb6fzYnH1GeRYeZk0HGqb2iNc4kBkxj0jW0rKw==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.24.4",
         "@babel/types": "^7.24.0",
         "@ndelangen/get-tarball": "^3.0.7",
-        "@storybook/codemod": "8.1.1",
-        "@storybook/core-common": "8.1.1",
-        "@storybook/core-events": "8.1.1",
-        "@storybook/core-server": "8.1.1",
-        "@storybook/csf-tools": "8.1.1",
-        "@storybook/node-logger": "8.1.1",
-        "@storybook/telemetry": "8.1.1",
-        "@storybook/types": "8.1.1",
+        "@storybook/codemod": "8.1.6",
+        "@storybook/core-common": "8.1.6",
+        "@storybook/core-events": "8.1.6",
+        "@storybook/core-server": "8.1.6",
+        "@storybook/csf-tools": "8.1.6",
+        "@storybook/node-logger": "8.1.6",
+        "@storybook/telemetry": "8.1.6",
+        "@storybook/types": "8.1.6",
         "@types/semver": "^7.3.4",
         "@yarnpkg/fslib": "2.10.3",
         "@yarnpkg/libzip": "2.3.0",
@@ -4049,13 +4290,152 @@
         "read-pkg-up": "^7.0.1",
         "semver": "^7.3.7",
         "strip-json-comments": "^3.0.1",
-        "tempy": "^1.0.1",
+        "tempy": "^3.1.0",
         "tiny-invariant": "^1.3.1",
         "ts-dedent": "^2.0.0"
       },
       "bin": {
         "getstorybook": "bin/index.js",
         "sb": "bin/index.js"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/cli/node_modules/@storybook/channels": {
+      "version": "8.1.6",
+      "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-8.1.6.tgz",
+      "integrity": "sha512-CzDnP6qfI8OC8pGUk+wPUzLPYcKhX8XbriF2gBtwl6qVM8YfkHP2mLTiDYDwBIi0rLuUbSm/SpILXQ/ouOHOGw==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/client-logger": "8.1.6",
+        "@storybook/core-events": "8.1.6",
+        "@storybook/global": "^5.0.0",
+        "telejson": "^7.2.0",
+        "tiny-invariant": "^1.3.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/cli/node_modules/@storybook/client-logger": {
+      "version": "8.1.6",
+      "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-8.1.6.tgz",
+      "integrity": "sha512-QfSoUxS1rmrBzO7o99og9g+Gkm7sTmU5ZOpTkjszjlRqfV6/77eUnUOzUikej4LqPLmlJV5fqGuvoP0aNVksDw==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/global": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/cli/node_modules/@storybook/core-common": {
+      "version": "8.1.6",
+      "resolved": "https://registry.npmjs.org/@storybook/core-common/-/core-common-8.1.6.tgz",
+      "integrity": "sha512-OTlfJFaTOB588ibXrrFm0TAXam6E5xV1VXSjNXL+fIifx8Kjln2HNSy1JKjvcblQneYiV4J1xPCVnAIe0EGHDg==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/core-events": "8.1.6",
+        "@storybook/csf-tools": "8.1.6",
+        "@storybook/node-logger": "8.1.6",
+        "@storybook/types": "8.1.6",
+        "@yarnpkg/fslib": "2.10.3",
+        "@yarnpkg/libzip": "2.3.0",
+        "chalk": "^4.1.0",
+        "cross-spawn": "^7.0.3",
+        "esbuild": "^0.18.0 || ^0.19.0 || ^0.20.0",
+        "esbuild-register": "^3.5.0",
+        "execa": "^5.0.0",
+        "file-system-cache": "2.3.0",
+        "find-cache-dir": "^3.0.0",
+        "find-up": "^5.0.0",
+        "fs-extra": "^11.1.0",
+        "glob": "^10.0.0",
+        "handlebars": "^4.7.7",
+        "lazy-universal-dotenv": "^4.0.0",
+        "node-fetch": "^2.0.0",
+        "picomatch": "^2.3.0",
+        "pkg-dir": "^5.0.0",
+        "prettier-fallback": "npm:prettier@^3",
+        "pretty-hrtime": "^1.0.3",
+        "resolve-from": "^5.0.0",
+        "semver": "^7.3.7",
+        "tempy": "^3.1.0",
+        "tiny-invariant": "^1.3.1",
+        "ts-dedent": "^2.0.0",
+        "util": "^0.12.4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "prettier": "^2 || ^3"
+      },
+      "peerDependenciesMeta": {
+        "prettier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@storybook/cli/node_modules/@storybook/core-events": {
+      "version": "8.1.6",
+      "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-8.1.6.tgz",
+      "integrity": "sha512-DaIVe4TUp/7uQdSJYGmJv9S/S364tSgZ3S3dZ1vsf1rgoUbCp5kTBtcd/fcqgukMPREgCgO9oDhmemI3SLAqzw==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/csf": "^0.1.7",
+        "ts-dedent": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/cli/node_modules/@storybook/csf-tools": {
+      "version": "8.1.6",
+      "resolved": "https://registry.npmjs.org/@storybook/csf-tools/-/csf-tools-8.1.6.tgz",
+      "integrity": "sha512-jrKfHFNhiLBhWWW4/fm2wgKEVg55e6QuYUHY16KGd7PdPuzm+2Pt7jIl5V9yIj6a59YbjeMpT6jWPKbFx2TuCw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/generator": "^7.24.4",
+        "@babel/parser": "^7.24.4",
+        "@babel/traverse": "^7.24.1",
+        "@babel/types": "^7.24.0",
+        "@storybook/csf": "^0.1.7",
+        "@storybook/types": "8.1.6",
+        "fs-extra": "^11.1.0",
+        "recast": "^0.23.5",
+        "ts-dedent": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/cli/node_modules/@storybook/node-logger": {
+      "version": "8.1.6",
+      "resolved": "https://registry.npmjs.org/@storybook/node-logger/-/node-logger-8.1.6.tgz",
+      "integrity": "sha512-IZEiTLFHu8Oom/vdEGpisSw5CfU+cw6/fTaX1P3EVClFOWVuy8/3X5MPu4wJH3jPym6E2DBduIUFeRsiuq61gA==",
+      "dev": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/cli/node_modules/@storybook/types": {
+      "version": "8.1.6",
+      "resolved": "https://registry.npmjs.org/@storybook/types/-/types-8.1.6.tgz",
+      "integrity": "sha512-cWpS9+x1pxCO39spR8QmumMK2ub2p5cvMtrRvWaIjBFPbCwm2CvjBXFWIra2veBCZTxUKJ9VWxvi7pzRHjN/nw==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/channels": "8.1.6",
+        "@types/express": "^4.7.0",
+        "file-system-cache": "2.3.0"
       },
       "funding": {
         "type": "opencollective",
@@ -4069,6 +4449,33 @@
       "dev": true,
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/@storybook/cli/node_modules/crypto-random-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-4.0.0.tgz",
+      "integrity": "sha512-x8dy3RnvYdlUcPOjkEHqozhiwzKNSq7GcPuXFbnyMOCHxX8V3OgIg/pYuabl2sbUPfIJaeAQB7PMOK8DFIdoRA==",
+      "dev": true,
+      "dependencies": {
+        "type-fest": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@storybook/cli/node_modules/crypto-random-string/node_modules/type-fest": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
+      "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@storybook/cli/node_modules/globby": {
@@ -4091,6 +4498,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@storybook/cli/node_modules/is-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+      "dev": true,
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/@storybook/cli/node_modules/path-type": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-5.0.0.tgz",
@@ -4103,6 +4522,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@storybook/cli/node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@storybook/cli/node_modules/slash": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
@@ -4110,6 +4538,60 @@
       "dev": true,
       "engines": {
         "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@storybook/cli/node_modules/temp-dir": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-3.0.0.tgz",
+      "integrity": "sha512-nHc6S/bwIilKHNRgK/3jlhDoIHcp45YgyiwcAk46Tr0LfEqGBVpmiAyuiuxeVE44m3mXnEeVhaipLOEWmH+Njw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.16"
+      }
+    },
+    "node_modules/@storybook/cli/node_modules/tempy": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tempy/-/tempy-3.1.0.tgz",
+      "integrity": "sha512-7jDLIdD2Zp0bDe5r3D2qtkd1QOCacylBuL7oa4udvN6v2pqr4+LcCr67C8DR1zkpaZ8XosF5m1yQSabKAW6f2g==",
+      "dev": true,
+      "dependencies": {
+        "is-stream": "^3.0.0",
+        "temp-dir": "^3.0.0",
+        "type-fest": "^2.12.2",
+        "unique-string": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@storybook/cli/node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@storybook/cli/node_modules/unique-string": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-3.0.0.tgz",
+      "integrity": "sha512-VGXBUVwxKMBUznyffQweQABPRRW1vHZAbadFZud4pLFAqRGvv/96vafgjWFqzourzr8YonlQiPgH0YCJfawoGQ==",
+      "dev": true,
+      "dependencies": {
+        "crypto-random-string": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -4129,18 +4611,18 @@
       }
     },
     "node_modules/@storybook/codemod": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/@storybook/codemod/-/codemod-8.1.1.tgz",
-      "integrity": "sha512-KfNf0XtMb2Hq1+v+2d660u2VhmmG5IMhPfdSClHh8Mer90CEGKvZpZQLn/Ph1REvzKfCW+MzEgn/JrEcJs8fHg==",
+      "version": "8.1.6",
+      "resolved": "https://registry.npmjs.org/@storybook/codemod/-/codemod-8.1.6.tgz",
+      "integrity": "sha512-N5JeimfscAOcME7FIrTCmxcsXxow11vtmPTjYWoeLYokBodaH5RyWcyyQ5KS1ACtt+dHYoX8lepSZA5SBEzYog==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.24.4",
         "@babel/preset-env": "^7.24.4",
         "@babel/types": "^7.24.0",
         "@storybook/csf": "^0.1.7",
-        "@storybook/csf-tools": "8.1.1",
-        "@storybook/node-logger": "8.1.1",
-        "@storybook/types": "8.1.1",
+        "@storybook/csf-tools": "8.1.6",
+        "@storybook/node-logger": "8.1.6",
+        "@storybook/types": "8.1.6",
         "@types/cross-spawn": "^6.0.2",
         "cross-spawn": "^7.0.3",
         "globby": "^14.0.1",
@@ -4149,6 +4631,96 @@
         "prettier": "^3.1.1",
         "recast": "^0.23.5",
         "tiny-invariant": "^1.3.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/codemod/node_modules/@storybook/channels": {
+      "version": "8.1.6",
+      "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-8.1.6.tgz",
+      "integrity": "sha512-CzDnP6qfI8OC8pGUk+wPUzLPYcKhX8XbriF2gBtwl6qVM8YfkHP2mLTiDYDwBIi0rLuUbSm/SpILXQ/ouOHOGw==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/client-logger": "8.1.6",
+        "@storybook/core-events": "8.1.6",
+        "@storybook/global": "^5.0.0",
+        "telejson": "^7.2.0",
+        "tiny-invariant": "^1.3.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/codemod/node_modules/@storybook/client-logger": {
+      "version": "8.1.6",
+      "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-8.1.6.tgz",
+      "integrity": "sha512-QfSoUxS1rmrBzO7o99og9g+Gkm7sTmU5ZOpTkjszjlRqfV6/77eUnUOzUikej4LqPLmlJV5fqGuvoP0aNVksDw==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/global": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/codemod/node_modules/@storybook/core-events": {
+      "version": "8.1.6",
+      "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-8.1.6.tgz",
+      "integrity": "sha512-DaIVe4TUp/7uQdSJYGmJv9S/S364tSgZ3S3dZ1vsf1rgoUbCp5kTBtcd/fcqgukMPREgCgO9oDhmemI3SLAqzw==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/csf": "^0.1.7",
+        "ts-dedent": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/codemod/node_modules/@storybook/csf-tools": {
+      "version": "8.1.6",
+      "resolved": "https://registry.npmjs.org/@storybook/csf-tools/-/csf-tools-8.1.6.tgz",
+      "integrity": "sha512-jrKfHFNhiLBhWWW4/fm2wgKEVg55e6QuYUHY16KGd7PdPuzm+2Pt7jIl5V9yIj6a59YbjeMpT6jWPKbFx2TuCw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/generator": "^7.24.4",
+        "@babel/parser": "^7.24.4",
+        "@babel/traverse": "^7.24.1",
+        "@babel/types": "^7.24.0",
+        "@storybook/csf": "^0.1.7",
+        "@storybook/types": "8.1.6",
+        "fs-extra": "^11.1.0",
+        "recast": "^0.23.5",
+        "ts-dedent": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/codemod/node_modules/@storybook/node-logger": {
+      "version": "8.1.6",
+      "resolved": "https://registry.npmjs.org/@storybook/node-logger/-/node-logger-8.1.6.tgz",
+      "integrity": "sha512-IZEiTLFHu8Oom/vdEGpisSw5CfU+cw6/fTaX1P3EVClFOWVuy8/3X5MPu4wJH3jPym6E2DBduIUFeRsiuq61gA==",
+      "dev": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/codemod/node_modules/@storybook/types": {
+      "version": "8.1.6",
+      "resolved": "https://registry.npmjs.org/@storybook/types/-/types-8.1.6.tgz",
+      "integrity": "sha512-cWpS9+x1pxCO39spR8QmumMK2ub2p5cvMtrRvWaIjBFPbCwm2CvjBXFWIra2veBCZTxUKJ9VWxvi7pzRHjN/nw==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/channels": "8.1.6",
+        "@types/express": "^4.7.0",
+        "file-system-cache": "2.3.0"
       },
       "funding": {
         "type": "opencollective",
@@ -4298,29 +4870,29 @@
       }
     },
     "node_modules/@storybook/core-server": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/@storybook/core-server/-/core-server-8.1.1.tgz",
-      "integrity": "sha512-/r70ORN9PdrLTLOeZfZkYhR/UBe6dj5DhcQ21zJhKU/0b10nuLJh4SGVD93Hah2wAYEN7YoJzX1bZMo6zRkTRQ==",
+      "version": "8.1.6",
+      "resolved": "https://registry.npmjs.org/@storybook/core-server/-/core-server-8.1.6.tgz",
+      "integrity": "sha512-rgkeTG8V4emzhPqjlhchsjLay0WtgK7SrXNf1X40oTJIwmbgbReLJ5EmOXBe9rhWSXJ13aKL3l6JuTLAoptSkg==",
       "dev": true,
       "dependencies": {
         "@aw-web-design/x-default-browser": "1.4.126",
         "@babel/core": "^7.24.4",
         "@babel/parser": "^7.24.4",
         "@discoveryjs/json-ext": "^0.5.3",
-        "@storybook/builder-manager": "8.1.1",
-        "@storybook/channels": "8.1.1",
-        "@storybook/core-common": "8.1.1",
-        "@storybook/core-events": "8.1.1",
+        "@storybook/builder-manager": "8.1.6",
+        "@storybook/channels": "8.1.6",
+        "@storybook/core-common": "8.1.6",
+        "@storybook/core-events": "8.1.6",
         "@storybook/csf": "^0.1.7",
-        "@storybook/csf-tools": "8.1.1",
+        "@storybook/csf-tools": "8.1.6",
         "@storybook/docs-mdx": "3.1.0-next.0",
         "@storybook/global": "^5.0.0",
-        "@storybook/manager": "8.1.1",
-        "@storybook/manager-api": "8.1.1",
-        "@storybook/node-logger": "8.1.1",
-        "@storybook/preview-api": "8.1.1",
-        "@storybook/telemetry": "8.1.1",
-        "@storybook/types": "8.1.1",
+        "@storybook/manager": "8.1.6",
+        "@storybook/manager-api": "8.1.6",
+        "@storybook/node-logger": "8.1.6",
+        "@storybook/preview-api": "8.1.6",
+        "@storybook/telemetry": "8.1.6",
+        "@storybook/types": "8.1.6",
         "@types/detect-port": "^1.3.0",
         "@types/diff": "^5.0.9",
         "@types/node": "^18.0.0",
@@ -4335,7 +4907,6 @@
         "express": "^4.17.3",
         "fs-extra": "^11.1.0",
         "globby": "^14.0.1",
-        "ip": "^2.0.1",
         "lodash": "^4.17.21",
         "open": "^8.4.0",
         "pretty-hrtime": "^1.0.3",
@@ -4355,13 +4926,275 @@
         "url": "https://opencollective.com/storybook"
       }
     },
+    "node_modules/@storybook/core-server/node_modules/@storybook/channels": {
+      "version": "8.1.6",
+      "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-8.1.6.tgz",
+      "integrity": "sha512-CzDnP6qfI8OC8pGUk+wPUzLPYcKhX8XbriF2gBtwl6qVM8YfkHP2mLTiDYDwBIi0rLuUbSm/SpILXQ/ouOHOGw==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/client-logger": "8.1.6",
+        "@storybook/core-events": "8.1.6",
+        "@storybook/global": "^5.0.0",
+        "telejson": "^7.2.0",
+        "tiny-invariant": "^1.3.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/core-server/node_modules/@storybook/client-logger": {
+      "version": "8.1.6",
+      "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-8.1.6.tgz",
+      "integrity": "sha512-QfSoUxS1rmrBzO7o99og9g+Gkm7sTmU5ZOpTkjszjlRqfV6/77eUnUOzUikej4LqPLmlJV5fqGuvoP0aNVksDw==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/global": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/core-server/node_modules/@storybook/core-common": {
+      "version": "8.1.6",
+      "resolved": "https://registry.npmjs.org/@storybook/core-common/-/core-common-8.1.6.tgz",
+      "integrity": "sha512-OTlfJFaTOB588ibXrrFm0TAXam6E5xV1VXSjNXL+fIifx8Kjln2HNSy1JKjvcblQneYiV4J1xPCVnAIe0EGHDg==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/core-events": "8.1.6",
+        "@storybook/csf-tools": "8.1.6",
+        "@storybook/node-logger": "8.1.6",
+        "@storybook/types": "8.1.6",
+        "@yarnpkg/fslib": "2.10.3",
+        "@yarnpkg/libzip": "2.3.0",
+        "chalk": "^4.1.0",
+        "cross-spawn": "^7.0.3",
+        "esbuild": "^0.18.0 || ^0.19.0 || ^0.20.0",
+        "esbuild-register": "^3.5.0",
+        "execa": "^5.0.0",
+        "file-system-cache": "2.3.0",
+        "find-cache-dir": "^3.0.0",
+        "find-up": "^5.0.0",
+        "fs-extra": "^11.1.0",
+        "glob": "^10.0.0",
+        "handlebars": "^4.7.7",
+        "lazy-universal-dotenv": "^4.0.0",
+        "node-fetch": "^2.0.0",
+        "picomatch": "^2.3.0",
+        "pkg-dir": "^5.0.0",
+        "prettier-fallback": "npm:prettier@^3",
+        "pretty-hrtime": "^1.0.3",
+        "resolve-from": "^5.0.0",
+        "semver": "^7.3.7",
+        "tempy": "^3.1.0",
+        "tiny-invariant": "^1.3.1",
+        "ts-dedent": "^2.0.0",
+        "util": "^0.12.4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "prettier": "^2 || ^3"
+      },
+      "peerDependenciesMeta": {
+        "prettier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@storybook/core-server/node_modules/@storybook/core-events": {
+      "version": "8.1.6",
+      "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-8.1.6.tgz",
+      "integrity": "sha512-DaIVe4TUp/7uQdSJYGmJv9S/S364tSgZ3S3dZ1vsf1rgoUbCp5kTBtcd/fcqgukMPREgCgO9oDhmemI3SLAqzw==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/csf": "^0.1.7",
+        "ts-dedent": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/core-server/node_modules/@storybook/csf-tools": {
+      "version": "8.1.6",
+      "resolved": "https://registry.npmjs.org/@storybook/csf-tools/-/csf-tools-8.1.6.tgz",
+      "integrity": "sha512-jrKfHFNhiLBhWWW4/fm2wgKEVg55e6QuYUHY16KGd7PdPuzm+2Pt7jIl5V9yIj6a59YbjeMpT6jWPKbFx2TuCw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/generator": "^7.24.4",
+        "@babel/parser": "^7.24.4",
+        "@babel/traverse": "^7.24.1",
+        "@babel/types": "^7.24.0",
+        "@storybook/csf": "^0.1.7",
+        "@storybook/types": "8.1.6",
+        "fs-extra": "^11.1.0",
+        "recast": "^0.23.5",
+        "ts-dedent": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/core-server/node_modules/@storybook/manager-api": {
+      "version": "8.1.6",
+      "resolved": "https://registry.npmjs.org/@storybook/manager-api/-/manager-api-8.1.6.tgz",
+      "integrity": "sha512-L/s1FdFh/P+eFmQwLtFtJHwFJrGD9H7nauaQlKJOrU3GeXfjBjtlAZQF0Q6B4ZTGxwZjQrzShpt/0yKc6gymtw==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/channels": "8.1.6",
+        "@storybook/client-logger": "8.1.6",
+        "@storybook/core-events": "8.1.6",
+        "@storybook/csf": "^0.1.7",
+        "@storybook/global": "^5.0.0",
+        "@storybook/icons": "^1.2.5",
+        "@storybook/router": "8.1.6",
+        "@storybook/theming": "8.1.6",
+        "@storybook/types": "8.1.6",
+        "dequal": "^2.0.2",
+        "lodash": "^4.17.21",
+        "memoizerific": "^1.11.3",
+        "store2": "^2.14.2",
+        "telejson": "^7.2.0",
+        "ts-dedent": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/core-server/node_modules/@storybook/node-logger": {
+      "version": "8.1.6",
+      "resolved": "https://registry.npmjs.org/@storybook/node-logger/-/node-logger-8.1.6.tgz",
+      "integrity": "sha512-IZEiTLFHu8Oom/vdEGpisSw5CfU+cw6/fTaX1P3EVClFOWVuy8/3X5MPu4wJH3jPym6E2DBduIUFeRsiuq61gA==",
+      "dev": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/core-server/node_modules/@storybook/preview-api": {
+      "version": "8.1.6",
+      "resolved": "https://registry.npmjs.org/@storybook/preview-api/-/preview-api-8.1.6.tgz",
+      "integrity": "sha512-g9EvVg/DYqmjMh1uivJBJnSIvURyuK4LLabYicQNmYdQJscAeXX2bpMcA4aeci9BBm9B2RP7JbSnq7DbXZaJYA==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/channels": "8.1.6",
+        "@storybook/client-logger": "8.1.6",
+        "@storybook/core-events": "8.1.6",
+        "@storybook/csf": "^0.1.7",
+        "@storybook/global": "^5.0.0",
+        "@storybook/types": "8.1.6",
+        "@types/qs": "^6.9.5",
+        "dequal": "^2.0.2",
+        "lodash": "^4.17.21",
+        "memoizerific": "^1.11.3",
+        "qs": "^6.10.0",
+        "tiny-invariant": "^1.3.1",
+        "ts-dedent": "^2.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/core-server/node_modules/@storybook/router": {
+      "version": "8.1.6",
+      "resolved": "https://registry.npmjs.org/@storybook/router/-/router-8.1.6.tgz",
+      "integrity": "sha512-tvuhB2uXHEKK640Epm1SqVzPhQ9lXYfF7FX6FleJgVYEvZpJpNTD4RojedQoLI6SUUSXNy1Vs2QV26VM0XIPHQ==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/client-logger": "8.1.6",
+        "memoizerific": "^1.11.3",
+        "qs": "^6.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/core-server/node_modules/@storybook/theming": {
+      "version": "8.1.6",
+      "resolved": "https://registry.npmjs.org/@storybook/theming/-/theming-8.1.6.tgz",
+      "integrity": "sha512-0Cl/7/0z2WSfXhZ9XSw6rgEjb0fXac7jfktieX0vYo1YckrNpWFRQP9NCpVPAcYZaFLlRSOqYark6CLoutEsIg==",
+      "dev": true,
+      "dependencies": {
+        "@emotion/use-insertion-effect-with-fallbacks": "^1.0.1",
+        "@storybook/client-logger": "8.1.6",
+        "@storybook/global": "^5.0.0",
+        "memoizerific": "^1.11.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@storybook/core-server/node_modules/@storybook/types": {
+      "version": "8.1.6",
+      "resolved": "https://registry.npmjs.org/@storybook/types/-/types-8.1.6.tgz",
+      "integrity": "sha512-cWpS9+x1pxCO39spR8QmumMK2ub2p5cvMtrRvWaIjBFPbCwm2CvjBXFWIra2veBCZTxUKJ9VWxvi7pzRHjN/nw==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/channels": "8.1.6",
+        "@types/express": "^4.7.0",
+        "file-system-cache": "2.3.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
     "node_modules/@storybook/core-server/node_modules/@types/node": {
-      "version": "18.19.33",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.33.tgz",
-      "integrity": "sha512-NR9+KrpSajr2qBVp/Yt5TU/rp+b5Mayi3+OlMlcg2cVCfRmcG5PWZ7S4+MG9PZ5gWBoc9Pd0BKSRViuBCRPu0A==",
+      "version": "18.19.34",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.34.tgz",
+      "integrity": "sha512-eXF4pfBNV5DAMKGbI02NnDtWrQ40hAN558/2vvS4gMpMIxaf6JmD7YjnZbq0Q9TDSSkKBamime8ewRoomHdt4g==",
       "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/@storybook/core-server/node_modules/crypto-random-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-4.0.0.tgz",
+      "integrity": "sha512-x8dy3RnvYdlUcPOjkEHqozhiwzKNSq7GcPuXFbnyMOCHxX8V3OgIg/pYuabl2sbUPfIJaeAQB7PMOK8DFIdoRA==",
+      "dev": true,
+      "dependencies": {
+        "type-fest": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@storybook/core-server/node_modules/crypto-random-string/node_modules/type-fest": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
+      "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@storybook/core-server/node_modules/globby": {
@@ -4384,6 +5217,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@storybook/core-server/node_modules/is-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+      "dev": true,
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/@storybook/core-server/node_modules/path-type": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-5.0.0.tgz",
@@ -4396,6 +5241,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@storybook/core-server/node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@storybook/core-server/node_modules/slash": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
@@ -4403,6 +5257,60 @@
       "dev": true,
       "engines": {
         "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@storybook/core-server/node_modules/temp-dir": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-3.0.0.tgz",
+      "integrity": "sha512-nHc6S/bwIilKHNRgK/3jlhDoIHcp45YgyiwcAk46Tr0LfEqGBVpmiAyuiuxeVE44m3mXnEeVhaipLOEWmH+Njw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.16"
+      }
+    },
+    "node_modules/@storybook/core-server/node_modules/tempy": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tempy/-/tempy-3.1.0.tgz",
+      "integrity": "sha512-7jDLIdD2Zp0bDe5r3D2qtkd1QOCacylBuL7oa4udvN6v2pqr4+LcCr67C8DR1zkpaZ8XosF5m1yQSabKAW6f2g==",
+      "dev": true,
+      "dependencies": {
+        "is-stream": "^3.0.0",
+        "temp-dir": "^3.0.0",
+        "type-fest": "^2.12.2",
+        "unique-string": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@storybook/core-server/node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@storybook/core-server/node_modules/unique-string": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-3.0.0.tgz",
+      "integrity": "sha512-VGXBUVwxKMBUznyffQweQABPRRW1vHZAbadFZud4pLFAqRGvv/96vafgjWFqzourzr8YonlQiPgH0YCJfawoGQ==",
+      "dev": true,
+      "dependencies": {
+        "crypto-random-string": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -4555,9 +5463,9 @@
       }
     },
     "node_modules/@storybook/manager": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/@storybook/manager/-/manager-8.1.1.tgz",
-      "integrity": "sha512-b3Oa9QsCbkTpH0LCKkMYDXtFYb1QpDc45EIFIm5Ib2tlilPQkx+a7jNpJG1/SKnYBwAO7iYjxN8iW9MwMLoCig==",
+      "version": "8.1.6",
+      "resolved": "https://registry.npmjs.org/@storybook/manager/-/manager-8.1.6.tgz",
+      "integrity": "sha512-B7xc09FYHqC1sknJoWkGHBBCMQlfg7hF+4x42cGhAyYed4TeYAf7b1PDniq8L/PLbUgzTw+A62UC1fMurCcVDQ==",
       "dev": true,
       "funding": {
         "type": "opencollective",
@@ -4978,14 +5886,14 @@
       }
     },
     "node_modules/@storybook/telemetry": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/@storybook/telemetry/-/telemetry-8.1.1.tgz",
-      "integrity": "sha512-yyrAc5t4UUb2OW6zpHM7/aI3ePiPcgMTyJqqn5X5+S9OHy0yHI7NHi7ZslTg6D5yXV6g3OTfa3Yq3pXkOBV3uw==",
+      "version": "8.1.6",
+      "resolved": "https://registry.npmjs.org/@storybook/telemetry/-/telemetry-8.1.6.tgz",
+      "integrity": "sha512-qNWjQPF6ufRvLCAavulhNYoqldDIeBvioFuCjLlwbw3BZw3ck7pwh1vZg4AJ0SAfzbnpnXPGrHe31gnxV0D6tw==",
       "dev": true,
       "dependencies": {
-        "@storybook/client-logger": "8.1.1",
-        "@storybook/core-common": "8.1.1",
-        "@storybook/csf-tools": "8.1.1",
+        "@storybook/client-logger": "8.1.6",
+        "@storybook/core-common": "8.1.6",
+        "@storybook/csf-tools": "8.1.6",
         "chalk": "^4.1.0",
         "detect-package-manager": "^2.0.1",
         "fetch-retry": "^5.0.2",
@@ -4995,6 +5903,247 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/telemetry/node_modules/@storybook/channels": {
+      "version": "8.1.6",
+      "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-8.1.6.tgz",
+      "integrity": "sha512-CzDnP6qfI8OC8pGUk+wPUzLPYcKhX8XbriF2gBtwl6qVM8YfkHP2mLTiDYDwBIi0rLuUbSm/SpILXQ/ouOHOGw==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/client-logger": "8.1.6",
+        "@storybook/core-events": "8.1.6",
+        "@storybook/global": "^5.0.0",
+        "telejson": "^7.2.0",
+        "tiny-invariant": "^1.3.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/telemetry/node_modules/@storybook/client-logger": {
+      "version": "8.1.6",
+      "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-8.1.6.tgz",
+      "integrity": "sha512-QfSoUxS1rmrBzO7o99og9g+Gkm7sTmU5ZOpTkjszjlRqfV6/77eUnUOzUikej4LqPLmlJV5fqGuvoP0aNVksDw==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/global": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/telemetry/node_modules/@storybook/core-common": {
+      "version": "8.1.6",
+      "resolved": "https://registry.npmjs.org/@storybook/core-common/-/core-common-8.1.6.tgz",
+      "integrity": "sha512-OTlfJFaTOB588ibXrrFm0TAXam6E5xV1VXSjNXL+fIifx8Kjln2HNSy1JKjvcblQneYiV4J1xPCVnAIe0EGHDg==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/core-events": "8.1.6",
+        "@storybook/csf-tools": "8.1.6",
+        "@storybook/node-logger": "8.1.6",
+        "@storybook/types": "8.1.6",
+        "@yarnpkg/fslib": "2.10.3",
+        "@yarnpkg/libzip": "2.3.0",
+        "chalk": "^4.1.0",
+        "cross-spawn": "^7.0.3",
+        "esbuild": "^0.18.0 || ^0.19.0 || ^0.20.0",
+        "esbuild-register": "^3.5.0",
+        "execa": "^5.0.0",
+        "file-system-cache": "2.3.0",
+        "find-cache-dir": "^3.0.0",
+        "find-up": "^5.0.0",
+        "fs-extra": "^11.1.0",
+        "glob": "^10.0.0",
+        "handlebars": "^4.7.7",
+        "lazy-universal-dotenv": "^4.0.0",
+        "node-fetch": "^2.0.0",
+        "picomatch": "^2.3.0",
+        "pkg-dir": "^5.0.0",
+        "prettier-fallback": "npm:prettier@^3",
+        "pretty-hrtime": "^1.0.3",
+        "resolve-from": "^5.0.0",
+        "semver": "^7.3.7",
+        "tempy": "^3.1.0",
+        "tiny-invariant": "^1.3.1",
+        "ts-dedent": "^2.0.0",
+        "util": "^0.12.4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "prettier": "^2 || ^3"
+      },
+      "peerDependenciesMeta": {
+        "prettier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@storybook/telemetry/node_modules/@storybook/core-events": {
+      "version": "8.1.6",
+      "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-8.1.6.tgz",
+      "integrity": "sha512-DaIVe4TUp/7uQdSJYGmJv9S/S364tSgZ3S3dZ1vsf1rgoUbCp5kTBtcd/fcqgukMPREgCgO9oDhmemI3SLAqzw==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/csf": "^0.1.7",
+        "ts-dedent": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/telemetry/node_modules/@storybook/csf-tools": {
+      "version": "8.1.6",
+      "resolved": "https://registry.npmjs.org/@storybook/csf-tools/-/csf-tools-8.1.6.tgz",
+      "integrity": "sha512-jrKfHFNhiLBhWWW4/fm2wgKEVg55e6QuYUHY16KGd7PdPuzm+2Pt7jIl5V9yIj6a59YbjeMpT6jWPKbFx2TuCw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/generator": "^7.24.4",
+        "@babel/parser": "^7.24.4",
+        "@babel/traverse": "^7.24.1",
+        "@babel/types": "^7.24.0",
+        "@storybook/csf": "^0.1.7",
+        "@storybook/types": "8.1.6",
+        "fs-extra": "^11.1.0",
+        "recast": "^0.23.5",
+        "ts-dedent": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/telemetry/node_modules/@storybook/node-logger": {
+      "version": "8.1.6",
+      "resolved": "https://registry.npmjs.org/@storybook/node-logger/-/node-logger-8.1.6.tgz",
+      "integrity": "sha512-IZEiTLFHu8Oom/vdEGpisSw5CfU+cw6/fTaX1P3EVClFOWVuy8/3X5MPu4wJH3jPym6E2DBduIUFeRsiuq61gA==",
+      "dev": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/telemetry/node_modules/@storybook/types": {
+      "version": "8.1.6",
+      "resolved": "https://registry.npmjs.org/@storybook/types/-/types-8.1.6.tgz",
+      "integrity": "sha512-cWpS9+x1pxCO39spR8QmumMK2ub2p5cvMtrRvWaIjBFPbCwm2CvjBXFWIra2veBCZTxUKJ9VWxvi7pzRHjN/nw==",
+      "dev": true,
+      "dependencies": {
+        "@storybook/channels": "8.1.6",
+        "@types/express": "^4.7.0",
+        "file-system-cache": "2.3.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/telemetry/node_modules/crypto-random-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-4.0.0.tgz",
+      "integrity": "sha512-x8dy3RnvYdlUcPOjkEHqozhiwzKNSq7GcPuXFbnyMOCHxX8V3OgIg/pYuabl2sbUPfIJaeAQB7PMOK8DFIdoRA==",
+      "dev": true,
+      "dependencies": {
+        "type-fest": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@storybook/telemetry/node_modules/crypto-random-string/node_modules/type-fest": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
+      "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@storybook/telemetry/node_modules/is-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+      "dev": true,
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@storybook/telemetry/node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@storybook/telemetry/node_modules/temp-dir": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-3.0.0.tgz",
+      "integrity": "sha512-nHc6S/bwIilKHNRgK/3jlhDoIHcp45YgyiwcAk46Tr0LfEqGBVpmiAyuiuxeVE44m3mXnEeVhaipLOEWmH+Njw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.16"
+      }
+    },
+    "node_modules/@storybook/telemetry/node_modules/tempy": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tempy/-/tempy-3.1.0.tgz",
+      "integrity": "sha512-7jDLIdD2Zp0bDe5r3D2qtkd1QOCacylBuL7oa4udvN6v2pqr4+LcCr67C8DR1zkpaZ8XosF5m1yQSabKAW6f2g==",
+      "dev": true,
+      "dependencies": {
+        "is-stream": "^3.0.0",
+        "temp-dir": "^3.0.0",
+        "type-fest": "^2.12.2",
+        "unique-string": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@storybook/telemetry/node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@storybook/telemetry/node_modules/unique-string": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-3.0.0.tgz",
+      "integrity": "sha512-VGXBUVwxKMBUznyffQweQABPRRW1vHZAbadFZud4pLFAqRGvv/96vafgjWFqzourzr8YonlQiPgH0YCJfawoGQ==",
+      "dev": true,
+      "dependencies": {
+        "crypto-random-string": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@storybook/test": {
@@ -10764,9 +11913,9 @@
       "dev": true
     },
     "node_modules/flow-parser": {
-      "version": "0.236.0",
-      "resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.236.0.tgz",
-      "integrity": "sha512-0OEk9Gr+Yj7wjDW2KgaNYUypKau71jAfFyeLQF5iVtxqc6uJHag/MT7pmaEApf4qM7u86DkBcd4ualddYMfbLw==",
+      "version": "0.237.2",
+      "resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.237.2.tgz",
+      "integrity": "sha512-mvI/kdfr3l1waaPbThPA8dJa77nHXrfZIun+SWvFwSwDjmeByU7mGJGRmv1+7guU6ccyLV8e1lqZA1lD4iMGnQ==",
       "dev": true,
       "engines": {
         "node": ">=0.4.0"
@@ -11758,12 +12907,6 @@
       "dependencies": {
         "loose-envify": "^1.0.0"
       }
-    },
-    "node_modules/ip": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.1.tgz",
-      "integrity": "sha512-lJUL9imLTNi1ZfXT+DU6rBBdbiKGBuay9B6xGSPVjUeQwaH1RIGqef8RZkUtHioLmSNpPR5M4HVKJGm1j8FWVQ==",
-      "dev": true
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
@@ -15793,9 +16936,9 @@
       }
     },
     "node_modules/spdx-license-ids": {
-      "version": "3.0.17",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.17.tgz",
-      "integrity": "sha512-sh8PWc/ftMqAAdFiBu6Fy6JUOYjqDJBJvIhpfDMyHrr0Rbp5liZqd4TjtQ/RgfLjKFZb+LMx5hpml5qOWy0qvg==",
+      "version": "3.0.18",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.18.tgz",
+      "integrity": "sha512-xxRs31BqRYHwiMzudOrpSiHtZ8i/GeionCBDSilhYRj+9gIcI8wCZTlXZKu9vZIVqViP3dcp9qE5G6AlIaD+TQ==",
       "dev": true
     },
     "node_modules/stackframe": {
@@ -15832,12 +16975,12 @@
       "dev": true
     },
     "node_modules/storybook": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/storybook/-/storybook-8.1.1.tgz",
-      "integrity": "sha512-tkoz1O2UcPOkfRgl/QkefI/1akyjkBghuX+2S/FaXb9cKUR1St4WBQfFqDUvJr1T9MKdizCBVFQ5HuqYzCiWWQ==",
+      "version": "8.1.6",
+      "resolved": "https://registry.npmjs.org/storybook/-/storybook-8.1.6.tgz",
+      "integrity": "sha512-qouQEB+sSb9ktE6fGVoBy6CLEUq4NOqDUpt/EhnITaWqzUeAZSQXTcoHg9DXhTMiynnbfqsUcZuK9PZOjgt7/w==",
       "dev": true,
       "dependencies": {
-        "@storybook/cli": "8.1.1"
+        "@storybook/cli": "8.1.6"
       },
       "bin": {
         "sb": "index.js",
@@ -16433,6 +17576,7 @@
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
       "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
       "dev": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
@@ -16453,6 +17597,7 @@
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
       "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
       "dev": true,
       "dependencies": {
         "glob": "^7.1.3"

--- a/src/apis/apiHooks/MyActivities.ts
+++ b/src/apis/apiHooks/MyActivities.ts
@@ -49,6 +49,7 @@ export function UseGetDashboard({ activityId, year, month }: UseGetDashboardPara
       );
       return data;
     },
+    enabled: !!activityId,
   });
 }
 

--- a/src/apis/apiHooks/MyActivities.ts
+++ b/src/apis/apiHooks/MyActivities.ts
@@ -1,0 +1,164 @@
+import { useQuery, useMutation } from '@tanstack/react-query';
+import { axiosInstanceToken } from '../axiosInstance';
+import { END_POINT } from '@/constants/';
+import useGetCookie from '@/hooks/useCookies';
+
+// 1. 내 체험 리스트 조회
+interface UseGetMyReservationListParams {
+  offset: number;
+  limit: number;
+}
+
+export function UseGetMyReservationList(params?: UseGetMyReservationListParams) {
+  const { getCookie } = useGetCookie();
+  const accessToken = getCookie('accessToken');
+  const { offset, limit } = params || {};
+
+  return useQuery({
+    queryKey: ['reservation', { offset, limit }],
+    queryFn: async () => {
+      if (!accessToken) throw new Error('Access token is not available');
+      const { data } = await axiosInstanceToken(accessToken).get(`${END_POINT.MY_ACTIVITIES}`, {
+        params: { offset, limit },
+      });
+      return data;
+    },
+  });
+}
+
+// 2. 내 체험 월별 예약 현황 조회
+interface UseGetDashboardParams {
+  activityId: number;
+  year: string;
+  month: string;
+}
+
+export function UseGetDashboard({ activityId, year, month }: UseGetDashboardParams) {
+  const { getCookie } = useGetCookie();
+  const accessToken = getCookie('accessToken');
+
+  return useQuery({
+    queryKey: ['reservation', { activityId, year, month }],
+    queryFn: async () => {
+      if (!accessToken) throw new Error('Access token is not available');
+      const { data } = await axiosInstanceToken(accessToken).get(
+        `${END_POINT.MY_ACTIVITIES}/${activityId}/reservation-dashboard`,
+        {
+          params: { year, month },
+        },
+      );
+      return data;
+    },
+  });
+}
+
+// 3. 내 체험 날짜별 예약 정보(신청, 승인, 거절)이 있는 스케줄 조회
+interface UseGetScheduleParams {
+  activityId: number;
+  date: string;
+}
+
+export function UseGetSchedule({ activityId, date }: UseGetScheduleParams) {
+  const { getCookie } = useGetCookie();
+  const accessToken = getCookie('accessToken');
+
+  return useQuery({
+    queryKey: ['reservation', { activityId, date }],
+    queryFn: async () => {
+      if (!accessToken) throw new Error('Access token is not available');
+      const { data } = await axiosInstanceToken(accessToken).get(
+        `${END_POINT.MY_ACTIVITIES}/${activityId}/reserved-schedule`,
+        {
+          params: { date },
+        },
+      );
+      return data;
+    },
+  });
+}
+
+// 4. 내 체험 예약 시간대별 예약 내역 조회
+interface UseGetScheduleHistoryParams {
+  activityId: number;
+  status: 'pending' | 'confirmed' | 'completed';
+  scheduleId: number;
+}
+
+export function UseGetScheduleHistory({ activityId, status, scheduleId }: UseGetScheduleHistoryParams) {
+  const { getCookie } = useGetCookie();
+  const accessToken = getCookie('accessToken');
+
+  return useQuery({
+    queryKey: ['reservation', { activityId, status, scheduleId }],
+    queryFn: async () => {
+      if (!accessToken) throw new Error('Access token is not available');
+      const { data } = await axiosInstanceToken(accessToken).get(
+        `${END_POINT.MY_ACTIVITIES}/${activityId}/reservations`,
+        {
+          params: { status, scheduleId },
+        },
+      );
+      return data;
+    },
+  });
+}
+
+// 5. 내 체험 예약 상태(승인, 거절) 업데이트
+interface UsePatchScheduleStatusParams {
+  activityId: number;
+  reservationId: number;
+}
+
+export function UsePatchScheduleStatus({ activityId, reservationId }: UsePatchScheduleStatusParams) {
+  const { getCookie } = useGetCookie();
+  const accessToken = getCookie('accessToken');
+
+  return useMutation({
+    mutationFn: async () => {
+      if (!accessToken) throw new Error('Access token is not available');
+      const { data } = await axiosInstanceToken(accessToken).get(
+        `${END_POINT.MY_ACTIVITIES}/${activityId}/reservations/${reservationId}`,
+        {
+          params: { reservationId },
+        },
+      );
+      return data;
+    },
+  });
+}
+
+// 6. 내 체험 삭제
+interface UseDeleteScheduleParams {
+  activityId: number;
+}
+
+export function UseDeleteSchedule({ activityId }: UseDeleteScheduleParams) {
+  const { getCookie } = useGetCookie();
+  const accessToken = getCookie('accessToken');
+
+  return useMutation({
+    mutationFn: async () => {
+      if (!accessToken) throw new Error('Access token is not available');
+      const { data } = await axiosInstanceToken(accessToken).get(`${END_POINT.MY_ACTIVITIES}/${activityId}`);
+      return data;
+    },
+  });
+}
+
+// 7. 내 체험 수정
+interface UseUpdateScheduleParams {
+  activityId: number;
+}
+
+export function UseUpdateSchedule({ activityId }: UseUpdateScheduleParams) {
+  const { getCookie } = useGetCookie();
+  const accessToken = getCookie('accessToken');
+
+  return useMutation({
+    mutationFn: async () => {
+      if (!accessToken) throw new Error('Access token is not available');
+      const { data } = await axiosInstanceToken(accessToken).get(`${END_POINT.MY_ACTIVITIES}/${activityId}`);
+      return data;
+    },
+  });
+}

--- a/src/apis/apiHooks/MyReservations.ts
+++ b/src/apis/apiHooks/MyReservations.ts
@@ -4,23 +4,18 @@ import { END_POINT } from '@/constants/';
 import useGetCookie from '@/hooks/useCookies';
 
 // 1. 내 예약 리스트 조회
-export function useGetReservation() {
-  const { getCookie, updateCookie } = useGetCookie();
+export function useGetReservation(status?: string) {
+  const { getCookie } = useGetCookie();
   const accessToken = getCookie('accessToken');
-  const reservationId = getCookie('reservationId');
 
   return useQuery({
-    queryKey: ['reservation', reservationId],
+    queryKey: ['reservation', status],
     queryFn: async () => {
       if (!accessToken) throw new Error('Access token is not available');
-      if (!reservationId) throw new Error('reservationId is not available');
-      const { data } = await axiosInstanceToken(accessToken).get(
-        `${END_POINT.MY_RESERVATIONS}/${reservationId}/reviews`,
-      );
+      const { data } = await axiosInstanceToken(accessToken).get(`${END_POINT.MY_RESERVATIONS}`, {
+        params: { status },
+      });
       return data;
-    },
-    select: (data) => {
-      updateCookie('reservationId', data.reservations[0].id);
     },
   });
 }

--- a/src/apis/apiHooks/MyReservations.ts
+++ b/src/apis/apiHooks/MyReservations.ts
@@ -4,18 +4,23 @@ import { END_POINT } from '@/constants/';
 import useGetCookie from '@/hooks/useCookies';
 
 // 1. 내 예약 리스트 조회
-export function useGetReservation(status?: string) {
-  const { getCookie } = useGetCookie();
+export function useGetReservation() {
+  const { getCookie, updateCookie } = useGetCookie();
   const accessToken = getCookie('accessToken');
+  const reservationId = getCookie('reservationId');
 
   return useQuery({
-    queryKey: ['reservation', status],
+    queryKey: ['reservation', reservationId],
     queryFn: async () => {
       if (!accessToken) throw new Error('Access token is not available');
-      const { data } = await axiosInstanceToken(accessToken).get(`${END_POINT.MY_RESERVATIONS}`, {
-        params: { status },
-      });
+      if (!reservationId) throw new Error('reservationId is not available');
+      const { data } = await axiosInstanceToken(accessToken).get(
+        `${END_POINT.MY_RESERVATIONS}/${reservationId}/reviews`,
+      );
       return data;
+    },
+    select: (data) => {
+      updateCookie('reservationId', data.reservations[0].id);
     },
   });
 }

--- a/src/components/Category&Filter/Category/Category.module.scss
+++ b/src/components/Category&Filter/Category/Category.module.scss
@@ -1,33 +1,64 @@
 .container {
-  display: flex;
-  gap: 2.4rem;
   @include tablet {
     gap: 1.4rem;
   }
+
   @include mobile {
     gap: 0.8rem;
   }
-}
-.wrapper {
-  display: flex;
-  width: 12.7rem;
-  padding: 1.6rem 3rem;
-  justify-content: center;
-  align-items: center;
-  border-radius: 1.5rem;
-  border: 0.1rem solid $green-200;
-  background: $white;
-  color: $green-200;
-  text-align: center;
-  white-space: nowrap;
-  @include pretendard-18-500;
-  @include mobile {
-    @include pretendard-14-400;
-    width: 10rem;
-    padding: 1.6rem 2rem;
+
+  .scroll-wrapper {
+    display: flex;
+    flex-direction: row;
+    justify-content: flex-start;
+    align-items: center;
+    gap: 2.4rem;
+    overflow-x: auto;
+    &::-webkit-scrollbar {
+      display: none;
+    }
+
+    .wrapper {
+      background: $white;
+      border-radius: 1.5rem;
+      border: 0.1rem solid $green-200;
+
+      min-width: 12.7rem;
+      height: 5.3rem;
+
+      display: flex;
+      justify-content: center;
+      align-items: center;
+
+      padding: 1.6rem 3rem;
+
+      @include pretendard-18-500;
+      color: $green-200;
+      text-align: center;
+      white-space: nowrap;
+
+      &:hover {
+        cursor: pointer;
+      }
+
+      @include tablet {
+        min-width: 12rem;
+      }
+
+      @include mobile {
+        min-width: 8rem;
+        height: 4.1rem;
+
+        padding: 1.2rem 2rem;
+
+        @include pretendard-14-400;
+      }
+    }
+
+    .clickedItem {
+      background: $nomad-black;
+
+      color: $white;
+    }
   }
-}
-.clickedItem {
-  background: $nomad-black;
-  color: $white;
 }

--- a/src/components/Category&Filter/Category/Category.tsx
+++ b/src/components/Category&Filter/Category/Category.tsx
@@ -1,14 +1,15 @@
 import { useState } from 'react';
-
 import classNames from 'classnames/bind';
 import styles from './Category.module.scss';
 
 const cn = classNames.bind(styles);
 
 interface CategoryProps {
+  className?: string;
   list: string[];
+  onSelect: (index: number) => void;
 }
-export default function Category({ list }: CategoryProps) {
+export default function Category({ className, list, onSelect }: CategoryProps) {
   const [clicked, setClicked] = useState<string | ''>('');
 
   const handleCategoryClick = (item: string) => {
@@ -16,16 +17,23 @@ export default function Category({ list }: CategoryProps) {
   };
 
   return (
-    <div className={cn('container')}>
-      {list.map((item, index) => (
-        <div
-          className={cn('wrapper', { clickedItem: clicked === item })}
-          onClick={() => handleCategoryClick(item)}
-          key={`${index} ${item}`}
-        >
-          {item}
-        </div>
-      ))}
+    <div className={cn('container', className)}>
+      <div className={cn('scroll-wrapper')}>
+        {list.map((item, index) => (
+          <div
+            className={cn('wrapper', { clickedItem: clicked === item })}
+            onClick={() => {
+              handleCategoryClick(item);
+              if (onSelect) {
+                onSelect(index);
+              }
+            }}
+            key={`${index} ${item}`}
+          >
+            {item}
+          </div>
+        ))}
+      </div>
     </div>
   );
 }

--- a/src/components/Dropdown/Dropdown.module.scss
+++ b/src/components/Dropdown/Dropdown.module.scss
@@ -49,12 +49,15 @@
   }
 
   .menuItems {
+    background-color: $white;
     width: 100%;
     padding: 0.8rem;
     margin-top: 0.8rem;
     list-style-type: none;
     border-radius: 0.6rem;
+    position: absolute;
     box-shadow: 0px 1rem 3rem 0.3rem rgba($box-shadow, 0.15);
+    z-index: $zindex-modal;
 
     .item {
       padding: 0.8rem 3.6rem;

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -9,7 +9,7 @@ const cn = classNames.bind(styles);
 
 interface DropdownProps {
   menuItems?: string[];
-  onSelect?: (selectedItem: string) => void;
+  onSelect?: (index: number) => void;
   className?: string;
   isLabelVisible: boolean;
 }
@@ -48,7 +48,7 @@ export function Dropdown({
                 setSelectedItem(item);
                 setIsDropdownOpen(false);
                 if (onSelect) {
-                  onSelect(item);
+                  onSelect(index);
                 }
               }}
             >

--- a/src/pageLayouts/ReservationCalendarLayout/ReservationCalendarLayout.tsx
+++ b/src/pageLayouts/ReservationCalendarLayout/ReservationCalendarLayout.tsx
@@ -1,3 +1,4 @@
+import { useState, useEffect } from 'react';
 import classNames from 'classnames/bind';
 import styles from './ReservationCalendarLayout.module.scss';
 
@@ -7,32 +8,88 @@ import EmptyIcon from '@/images/icon/icon_empty.svg';
 
 const cn = classNames.bind(styles);
 
-interface ReservationCalendarLayoutProps {
-  reservationData?: boolean;
+interface Reservation {
+  activity: {
+    id: number;
+    title: string;
+  };
+  date: string;
+  endTime: string;
+  headCount: number;
+  id: number;
+  reviewSubmitted: false;
+  scheduleId: number;
+  startTime: string;
+  status: 'declined' | 'confirmed' | 'pending';
+  totalPrice: number;
+  userId: number;
 }
 
-export default function ReservationCalendarLayout({ reservationData = false }: ReservationCalendarLayoutProps) {
+interface DataProps {
+  data?: {
+    reservations: Reservation[];
+  };
+}
+
+export default function ReservationCalendarLayout(data: DataProps) {
+  const [reservationTitleList, setReservationTitleList] = useState<[string, number][] | null>(null);
+  const [reservationDataList, setReservationDataList] = useState<Reservation[] | null>(null);
+  const [selectedItemData, setSelectedItemData] = useState<Reservation[] | null>(null);
+
+  useEffect(() => {
+    if (data.data?.reservations) {
+      const { reservations } = data.data;
+
+      const unDuplicateTitles: [string, number][] = reservations
+        .filter(
+          (reservation, index, self) => index === self.findIndex((t) => t.activity.id === reservation.activity.id),
+        )
+        .map((reservation) => [reservation.activity.title, reservation.activity.id]);
+
+      setReservationTitleList(unDuplicateTitles);
+      setReservationDataList(reservations);
+
+      if (unDuplicateTitles.length > 0) {
+        const initialSelectedId = unDuplicateTitles[0][1];
+        const initialSelectedItems = reservations.filter((item) => item.activity.id === initialSelectedId);
+        setSelectedItemData(initialSelectedItems);
+      }
+    }
+  }, [data]);
+
+  const onDropdownSelect = (index: number) => {
+    if (reservationTitleList && reservationDataList) {
+      const selectedId = reservationTitleList?.[index][1];
+      const selectedItems = reservationDataList?.filter((item) => item.activity.id === selectedId);
+      setSelectedItemData(selectedItems);
+    }
+  };
+
+  if (!reservationTitleList || !reservationDataList) {
+    return (
+      <div className={cn('wrapper')}>
+        <div className={cn('header')}>
+          <div className={cn('text')}>예약 현황</div>
+        </div>
+        <div className={cn('empty')}>
+          <EmptyIcon width="24rem" height="24rem" viewBox="0 0 240 240" />
+          <div className={cn('description')}>아직 등록한 체험이 없어요</div>
+        </div>
+      </div>
+    );
+  }
+
   return (
-    <>
-      {reservationData ? (
-        <div className={cn('wrapper')}>
-          <div className={cn('header')}>
-            <div className={cn('text')}>예약 현황</div>
-            <Dropdown isLabelVisible={true} />
-          </div>
-          <CalendarLayout />
-        </div>
-      ) : (
-        <div className={cn('wrapper')}>
-          <div className={cn('header')}>
-            <div className={cn('text')}>예약 현황</div>
-          </div>
-          <div className={cn('empty')}>
-            <EmptyIcon width="24rem" height="24rem" viewBox="0 0 240 240" />
-            <div className={cn('description')}>아직 등록한 체험이 없어요</div>
-          </div>
-        </div>
-      )}
-    </>
+    <div className={cn('wrapper')}>
+      <div className={cn('header')}>
+        <div className={cn('text')}>예약 현황</div>
+        <Dropdown
+          isLabelVisible={true}
+          menuItems={reservationTitleList.map((item) => item[0])}
+          onSelect={onDropdownSelect}
+        />
+      </div>
+      <CalendarLayout data={selectedItemData} />
+    </div>
   );
 }

--- a/src/pageLayouts/ReservationCalendarLayout/ReservationCalendarLayout.tsx
+++ b/src/pageLayouts/ReservationCalendarLayout/ReservationCalendarLayout.tsx
@@ -8,64 +8,51 @@ import EmptyIcon from '@/images/icon/icon_empty.svg';
 
 const cn = classNames.bind(styles);
 
-interface Reservation {
-  activity: {
-    id: number;
-    title: string;
-  };
-  date: string;
-  endTime: string;
-  headCount: number;
+interface Activity {
   id: number;
-  reviewSubmitted: false;
-  scheduleId: number;
-  startTime: string;
-  status: 'declined' | 'confirmed' | 'pending';
-  totalPrice: number;
   userId: number;
+  title: string;
 }
 
-interface DataProps {
-  data?: {
-    reservations: Reservation[];
+interface ActivityListProps {
+  activityList?: {
+    activities: Activity[];
   };
 }
 
-export default function ReservationCalendarLayout(data: DataProps) {
-  const [reservationTitleList, setReservationTitleList] = useState<[string, number][] | null>(null);
-  const [reservationDataList, setReservationDataList] = useState<Reservation[] | null>(null);
-  const [selectedItemData, setSelectedItemData] = useState<Reservation[] | null>(null);
+export default function ReservationCalendarLayout(activityList: ActivityListProps) {
+  const [activityListData, setActivityListData] = useState<Activity[] | null>(null);
+  const [dropdownTitleList, setDropdownTitleList] = useState<[string, number][] | null>(null);
+  const [selectedActivity, setSelectedActivity] = useState<Activity[] | null>(null);
 
   useEffect(() => {
-    if (data.data?.reservations) {
-      const { reservations } = data.data;
+    if (activityList.activityList?.activities) {
+      const { activities } = activityList.activityList;
 
-      const unDuplicateTitles: [string, number][] = reservations
-        .filter(
-          (reservation, index, self) => index === self.findIndex((t) => t.activity.id === reservation.activity.id),
-        )
-        .map((reservation) => [reservation.activity.title, reservation.activity.id]);
+      const unDuplicateTitles: [string, number][] = activities
+        .filter((activity, index, self) => index === self.findIndex((title) => title.id === activity.id))
+        .map((activity) => [activity.title, activity.id]);
 
-      setReservationTitleList(unDuplicateTitles);
-      setReservationDataList(reservations);
+      setDropdownTitleList(unDuplicateTitles);
+      setActivityListData(activities);
 
       if (unDuplicateTitles.length > 0) {
         const initialSelectedId = unDuplicateTitles[0][1];
-        const initialSelectedItems = reservations.filter((item) => item.activity.id === initialSelectedId);
-        setSelectedItemData(initialSelectedItems);
+        const initialSelectedItems = activities.filter((item) => item.id === initialSelectedId);
+        setSelectedActivity(initialSelectedItems);
       }
     }
-  }, [data]);
+  }, [activityList]);
 
   const onDropdownSelect = (index: number) => {
-    if (reservationTitleList && reservationDataList) {
-      const selectedId = reservationTitleList?.[index][1];
-      const selectedItems = reservationDataList?.filter((item) => item.activity.id === selectedId);
-      setSelectedItemData(selectedItems);
+    if (dropdownTitleList && activityListData) {
+      const selectedId = dropdownTitleList?.[index][1];
+      const selectedItems = activityListData?.filter((item) => item.id === selectedId);
+      setSelectedActivity(selectedItems);
     }
   };
 
-  if (!reservationTitleList || !reservationDataList) {
+  if (!dropdownTitleList || !activityListData) {
     return (
       <div className={cn('wrapper')}>
         <div className={cn('header')}>
@@ -85,11 +72,11 @@ export default function ReservationCalendarLayout(data: DataProps) {
         <div className={cn('text')}>예약 현황</div>
         <Dropdown
           isLabelVisible={true}
-          menuItems={reservationTitleList.map((item) => item[0])}
+          menuItems={dropdownTitleList.map((item) => item[0])}
           onSelect={onDropdownSelect}
         />
       </div>
-      <CalendarLayout data={selectedItemData} />
+      <CalendarLayout selectedActivity={selectedActivity} />
     </div>
   );
 }

--- a/src/pageLayouts/ReservationCalendarLayout/ReservationCalendarLayout.tsx
+++ b/src/pageLayouts/ReservationCalendarLayout/ReservationCalendarLayout.tsx
@@ -15,44 +15,31 @@ interface Activity {
 }
 
 interface ActivityListProps {
-  activityList?: {
+  activityList: {
     activities: Activity[];
   };
 }
 
 export default function ReservationCalendarLayout(activityList: ActivityListProps) {
   const [activityListData, setActivityListData] = useState<Activity[] | null>(null);
-  const [dropdownTitleList, setDropdownTitleList] = useState<[string, number][] | null>(null);
-  const [selectedActivity, setSelectedActivity] = useState<Activity[] | null>(null);
+  const [selectedActivity, setSelectedActivity] = useState<number | null>(null);
 
   useEffect(() => {
     if (activityList.activityList?.activities) {
       const { activities } = activityList.activityList;
-
-      const unDuplicateTitles: [string, number][] = activities
-        .filter((activity, index, self) => index === self.findIndex((title) => title.id === activity.id))
-        .map((activity) => [activity.title, activity.id]);
-
-      setDropdownTitleList(unDuplicateTitles);
       setActivityListData(activities);
 
-      if (unDuplicateTitles.length > 0) {
-        const initialSelectedId = unDuplicateTitles[0][1];
-        const initialSelectedItems = activities.filter((item) => item.id === initialSelectedId);
-        setSelectedActivity(initialSelectedItems);
-      }
+      setSelectedActivity(activities[0].id);
     }
   }, [activityList]);
 
   const onDropdownSelect = (index: number) => {
-    if (dropdownTitleList && activityListData) {
-      const selectedId = dropdownTitleList?.[index][1];
-      const selectedItems = activityListData?.filter((item) => item.id === selectedId);
-      setSelectedActivity(selectedItems);
+    if (activityListData) {
+      setSelectedActivity(activityListData[index].id);
     }
   };
 
-  if (!dropdownTitleList || !activityListData) {
+  if (!activityListData) {
     return (
       <div className={cn('wrapper')}>
         <div className={cn('header')}>
@@ -72,7 +59,7 @@ export default function ReservationCalendarLayout(activityList: ActivityListProp
         <div className={cn('text')}>예약 현황</div>
         <Dropdown
           isLabelVisible={true}
-          menuItems={dropdownTitleList.map((item) => item[0])}
+          menuItems={activityListData.map((item) => item.title)}
           onSelect={onDropdownSelect}
         />
       </div>

--- a/src/pageLayouts/ReservationCalendarLayout/components/CalendarLayout/CalendarLayout.module.scss
+++ b/src/pageLayouts/ReservationCalendarLayout/components/CalendarLayout/CalendarLayout.module.scss
@@ -8,7 +8,9 @@
   align-items: stretch;
   gap: 2.4rem;
 
-  padding-top: 3rem;
+  .category {
+    padding: 1rem 0 2rem;
+  }
 
   .header {
     width: 34.2rem;

--- a/src/pageLayouts/ReservationCalendarLayout/components/CalendarLayout/CalendarLayout.module.scss
+++ b/src/pageLayouts/ReservationCalendarLayout/components/CalendarLayout/CalendarLayout.module.scss
@@ -5,7 +5,7 @@
   display: flex;
   flex-direction: column;
   justify-content: space-between;
-  align-items: center;
+  align-items: stretch;
   gap: 2.4rem;
 
   padding-top: 3rem;
@@ -19,6 +19,8 @@
     justify-content: space-between;
     align-items: center;
     gap: 9.6rem;
+
+    margin: 0 auto;
 
     @include pretendard-20-700;
     color: $nomad-black;

--- a/src/pageLayouts/ReservationCalendarLayout/components/CalendarLayout/CalendarLayout.tsx
+++ b/src/pageLayouts/ReservationCalendarLayout/components/CalendarLayout/CalendarLayout.tsx
@@ -10,13 +10,7 @@ import { UseGetDashboard } from '@/apis/apiHooks/MyActivities';
 
 const cn = classNames.bind(styles);
 
-interface CalendarData {
-  id: number;
-  userId: number;
-  title: string;
-}
-
-export default function Calendar({ selectedActivity }: { selectedActivity: CalendarData[] | null }) {
+export default function Calendar({ selectedActivity }: { selectedActivity: number | null }) {
   const [currentMonth, setCurrentMonth] = useState(dayjs());
 
   const handlePreviousMonth = () => {
@@ -27,7 +21,7 @@ export default function Calendar({ selectedActivity }: { selectedActivity: Calen
     setCurrentMonth((nextMonth) => nextMonth.add(1, 'month'));
   };
 
-  const activityId = selectedActivity?.[0]?.id || 0;
+  const activityId = selectedActivity || 0;
   const { data: dashboardData } = UseGetDashboard({
     activityId,
     year: currentMonth.format('YYYY'),

--- a/src/pageLayouts/ReservationCalendarLayout/components/CalendarLayout/CalendarLayout.tsx
+++ b/src/pageLayouts/ReservationCalendarLayout/components/CalendarLayout/CalendarLayout.tsx
@@ -9,7 +9,24 @@ import CreateCalendar from '../CreateCalendar/CreateCalendar';
 
 const cn = classNames.bind(styles);
 
-export default function Calendar() {
+interface CalendarData {
+  activity: {
+    id: number;
+    title: string;
+  };
+  date: string;
+  endTime: string;
+  headCount: number;
+  id: number;
+  reviewSubmitted: false;
+  scheduleId: number;
+  startTime: string;
+  status: 'declined' | 'confirmed' | 'pending';
+  totalPrice: number;
+  userId: number;
+}
+
+export default function Calendar({ data }: { data: CalendarData[] | null }) {
   const [currentMonth, setCurrentMonth] = useState(dayjs());
 
   const handlePreviousMonth = () => {
@@ -40,7 +57,7 @@ export default function Calendar() {
             </div>
           ))}
         </div>
-        <CreateCalendar currentMonth={currentMonth} startOfMonth={startOfMonth} endOfMonth={endOfMonth} />
+        <CreateCalendar currentMonth={currentMonth} startOfMonth={startOfMonth} endOfMonth={endOfMonth} data={data} />
       </div>
     </div>
   );

--- a/src/pageLayouts/ReservationCalendarLayout/components/CalendarLayout/CalendarLayout.tsx
+++ b/src/pageLayouts/ReservationCalendarLayout/components/CalendarLayout/CalendarLayout.tsx
@@ -5,13 +5,24 @@ import dayjs from 'dayjs';
 
 import PrevArrow from '@/images/btn/btn_prev_arrow.svg';
 import NextArrow from '@/images/btn/btn_next_arrow.svg';
+import Category from '@/components/Category&Filter/Category/Category';
 import CreateCalendar from '../CreateCalendar/CreateCalendar';
 import { UseGetDashboard } from '@/apis/apiHooks/MyActivities';
 
 const cn = classNames.bind(styles);
 
+interface DashboardData {
+  date: string;
+  reservations: {
+    completed: number;
+    confirmed: number;
+    pending: number;
+  };
+}
+
 export default function Calendar({ selectedActivity }: { selectedActivity: number | null }) {
   const [currentMonth, setCurrentMonth] = useState(dayjs());
+  const [selectedCategory, setCurrentCategory] = useState('');
 
   const handlePreviousMonth = () => {
     setCurrentMonth((prevMonth) => prevMonth.subtract(1, 'month'));
@@ -26,9 +37,14 @@ export default function Calendar({ selectedActivity }: { selectedActivity: numbe
     activityId,
     year: currentMonth.format('YYYY'),
     month: currentMonth.format('MM'),
-  });
+  }) as { data: DashboardData[] | undefined };
+
+  const categoryList = [`완료`, `승인`, `예약`];
 
   const dayLabels = ['SUN', 'MON', 'TUE', 'WED', 'THUR', 'FRI', 'SAT'];
+  const onSelect = (index: number) => {
+    setCurrentCategory(categoryList[index]);
+  };
 
   return (
     <div className={cn('container')}>
@@ -37,6 +53,7 @@ export default function Calendar({ selectedActivity }: { selectedActivity: numbe
         <div>{currentMonth.format('YYYY년 M월')}</div>
         <NextArrow width="2.4rem" height="2.4rem" onClick={handleNextMonth} />
       </div>
+      <Category className={cn('category')} list={categoryList} onSelect={onSelect} />
       <div className={cn('content')}>
         <div className={cn('labelWrapper')}>
           {dayLabels.map((label, index) => (

--- a/src/pageLayouts/ReservationCalendarLayout/components/CalendarLayout/CalendarLayout.tsx
+++ b/src/pageLayouts/ReservationCalendarLayout/components/CalendarLayout/CalendarLayout.tsx
@@ -48,12 +48,13 @@ export default function Calendar({ selectedActivity }: { selectedActivity: numbe
 
   return (
     <div className={cn('container')}>
+      <Category className={cn('category')} list={categoryList} onSelect={onSelect} />
       <div className={cn('header')}>
         <PrevArrow width="2.4rem" height="2.4rem" onClick={handlePreviousMonth} />
         <div>{currentMonth.format('YYYY년 M월')}</div>
         <NextArrow width="2.4rem" height="2.4rem" onClick={handleNextMonth} />
       </div>
-      <Category className={cn('category')} list={categoryList} onSelect={onSelect} />
+
       <div className={cn('content')}>
         <div className={cn('labelWrapper')}>
           {dayLabels.map((label, index) => (

--- a/src/pageLayouts/ReservationCalendarLayout/components/CalendarLayout/CalendarLayout.tsx
+++ b/src/pageLayouts/ReservationCalendarLayout/components/CalendarLayout/CalendarLayout.tsx
@@ -6,27 +6,17 @@ import dayjs from 'dayjs';
 import PrevArrow from '@/images/btn/btn_prev_arrow.svg';
 import NextArrow from '@/images/btn/btn_next_arrow.svg';
 import CreateCalendar from '../CreateCalendar/CreateCalendar';
+import { UseGetDashboard } from '@/apis/apiHooks/MyActivities';
 
 const cn = classNames.bind(styles);
 
 interface CalendarData {
-  activity: {
-    id: number;
-    title: string;
-  };
-  date: string;
-  endTime: string;
-  headCount: number;
   id: number;
-  reviewSubmitted: false;
-  scheduleId: number;
-  startTime: string;
-  status: 'declined' | 'confirmed' | 'pending';
-  totalPrice: number;
   userId: number;
+  title: string;
 }
 
-export default function Calendar({ data }: { data: CalendarData[] | null }) {
+export default function Calendar({ selectedActivity }: { selectedActivity: CalendarData[] | null }) {
   const [currentMonth, setCurrentMonth] = useState(dayjs());
 
   const handlePreviousMonth = () => {
@@ -37,8 +27,12 @@ export default function Calendar({ data }: { data: CalendarData[] | null }) {
     setCurrentMonth((nextMonth) => nextMonth.add(1, 'month'));
   };
 
-  const startOfMonth = currentMonth.startOf('month');
-  const endOfMonth = currentMonth.endOf('month');
+  const activityId = selectedActivity?.[0]?.id || 0;
+  const { data: dashboardData } = UseGetDashboard({
+    activityId,
+    year: currentMonth.format('YYYY'),
+    month: currentMonth.format('MM'),
+  });
 
   const dayLabels = ['SUN', 'MON', 'TUE', 'WED', 'THUR', 'FRI', 'SAT'];
 
@@ -57,7 +51,7 @@ export default function Calendar({ data }: { data: CalendarData[] | null }) {
             </div>
           ))}
         </div>
-        <CreateCalendar currentMonth={currentMonth} startOfMonth={startOfMonth} endOfMonth={endOfMonth} data={data} />
+        <CreateCalendar currentMonth={currentMonth} dashboardData={dashboardData} />
       </div>
     </div>
   );

--- a/src/pageLayouts/ReservationCalendarLayout/components/CreateCalendar/CreateCalendar.tsx
+++ b/src/pageLayouts/ReservationCalendarLayout/components/CreateCalendar/CreateCalendar.tsx
@@ -8,86 +8,60 @@ import ElipseIconBlue from '@/images/icon/icon_ellipse_blue.svg';
 
 const cn = classNames.bind(styles);
 
-interface CalendarData {
-  activity: {
-    id: number;
-    title: string;
-  };
+interface dashboardDataProps {
   date: string;
-  endTime: string;
-  headCount: number;
-  id: number;
-  reviewSubmitted: false;
-  scheduleId: number;
-  startTime: string;
-  status: 'declined' | 'confirmed' | 'pending';
-  totalPrice: number;
-  userId: number;
+  reservations: {
+    completed: number;
+    confirmed: number;
+    pending: number;
+  };
 }
 
 interface CreateCalendarProps {
   currentMonth: dayjs.Dayjs;
-  endOfMonth: dayjs.Dayjs;
-  startOfMonth: dayjs.Dayjs;
-  data: CalendarData[] | null;
+  dashboardData: dashboardDataProps[];
 }
 
-export default function CreateCalendar({ currentMonth, endOfMonth, startOfMonth, data }: CreateCalendarProps) {
-  console.log(data);
+export default function CreateCalendar({ currentMonth, dashboardData = [] }: CreateCalendarProps) {
+  const startOfMonth = currentMonth.startOf('month');
+  const endOfMonth = currentMonth.endOf('month');
 
-  return (
-    <div className={cn('itemsWrapper')}>
-      {[...Array(endOfMonth.diff(startOfMonth, 'day') + 1)].map((_, i) => {
-        const day = startOfMonth.add(i, 'day');
-        if (day.month() === currentMonth.month()) {
-          const dayCompleteCount = data?.filter(
-            (item) => item.status === 'confirmed' && dayjs(item.date).isSame(day, 'day'),
-          ).length;
-          const dayReservationCount = data?.filter(
-            (item) => item.status === 'pending' && dayjs(item.date).isSame(day, 'day'),
-          ).length;
-          const dayConfirmCount = data?.filter(
-            (item) => item.status === 'confirmed' && dayjs(item.date).isSame(day, 'day'),
-          ).length;
+  const days = [...Array(endOfMonth.diff(startOfMonth, 'day') + 1)].map((_, i) => {
+    const day = startOfMonth.add(i, 'day');
 
-          const RenderAlertIcon = () => {
-            if (dayReservationCount || dayConfirmCount || dayCompleteCount) {
-              return dayReservationCount || dayConfirmCount ? (
-                <ElipseIconBlue className={cn('alertIcon')} />
-              ) : (
-                <ElipseIconGray className={cn('alertIcon')} />
-              );
-            }
-            return null;
-          };
+    const dashboardDataForThisDate = dashboardData?.find((d) => d.date === day.format('YYYY-MM-DD'));
 
-          return (
-            <div key={day.format('YYYY-MM-DD')} className={cn('item')}>
-              <div className={cn('dayWrapper')}>
-                {day.format('D')}
-                {RenderAlertIcon()}
-              </div>
-              <div className={cn('chips')}>
-                {dayCompleteCount ? (
-                  <Chips className={cn('chip')} type="confirmed">
-                    완료 {dayCompleteCount}
-                  </Chips>
-                ) : null}
-                {dayReservationCount ? (
-                  <Chips className={cn('chip')} type="reservation">
-                    예약 {dayReservationCount}
-                  </Chips>
-                ) : null}
-                {dayConfirmCount ? (
-                  <Chips className={cn('chip')} type="complete">
-                    승인 {dayConfirmCount}
-                  </Chips>
-                ) : null}
-              </div>
-            </div>
-          );
-        }
-      })}
-    </div>
-  );
+    const completedCount = dashboardDataForThisDate?.reservations.completed;
+    const pendingCount = dashboardDataForThisDate?.reservations.pending;
+    const confirmedCount = dashboardDataForThisDate?.reservations.confirmed;
+
+    return (
+      <div key={day.format('YYYY-MM-DD')} className={cn('item')}>
+        <div className={cn('dayWrapper')}>
+          {day.format('D')}
+          {completedCount ? <ElipseIconGray className={cn('alertIcon')} /> : null}
+          {pendingCount || confirmedCount ? <ElipseIconBlue className={cn('alertIcon')} /> : null}
+        </div>
+        <div className={cn('chips')}>
+          {completedCount ? (
+            <Chips className={cn('chip')} type="confirmed">
+              완료 {completedCount}
+            </Chips>
+          ) : null}
+          {pendingCount ? (
+            <Chips className={cn('chip')} type="reservation">
+              예약 {pendingCount}
+            </Chips>
+          ) : null}
+          {confirmedCount ? (
+            <Chips className={cn('chip')} type="complete">
+              승인 {confirmedCount}
+            </Chips>
+          ) : null}
+        </div>
+      </div>
+    );
+  });
+
+  return <div className={cn('itemsWrapper')}>{days}</div>;
 }

--- a/src/pageLayouts/ReservationCalendarLayout/components/CreateCalendar/CreateCalendar.tsx
+++ b/src/pageLayouts/ReservationCalendarLayout/components/CreateCalendar/CreateCalendar.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import classNames from 'classnames/bind';
 import styles from './CreateCalendar.module.scss';
 import dayjs from 'dayjs';
@@ -11,7 +12,7 @@ const cn = classNames.bind(styles);
 interface dashboardDataProps {
   date: string;
   reservations: {
-    completed: number;
+    declined: number;
     confirmed: number;
     pending: number;
   };
@@ -23,15 +24,19 @@ interface CreateCalendarProps {
 }
 
 export default function CreateCalendar({ currentMonth, dashboardData = [] }: CreateCalendarProps) {
+  const [completedCount, setCompletedCount] = useState(0);
   const startOfMonth = currentMonth.startOf('month');
   const endOfMonth = currentMonth.endOf('month');
+  console.log(dashboardData);
 
   const days = [...Array(endOfMonth.diff(startOfMonth, 'day') + 1)].map((_, i) => {
     const day = startOfMonth.add(i, 'day');
 
     const dashboardDataForThisDate = dashboardData?.find((d) => d.date === day.format('YYYY-MM-DD'));
 
-    const completedCount = dashboardDataForThisDate?.reservations.completed;
+    if (dashboardDataForThisDate?.reservations.confirmed && day.isBefore(day)) {
+      setCompletedCount(dashboardDataForThisDate?.reservations.confirmed);
+    }
     const pendingCount = dashboardDataForThisDate?.reservations.pending;
     const confirmedCount = dashboardDataForThisDate?.reservations.confirmed;
 
@@ -39,22 +44,23 @@ export default function CreateCalendar({ currentMonth, dashboardData = [] }: Cre
       <div key={day.format('YYYY-MM-DD')} className={cn('item')}>
         <div className={cn('dayWrapper')}>
           {day.format('D')}
-          {completedCount ? <ElipseIconGray className={cn('alertIcon')} /> : null}
-          {pendingCount || confirmedCount ? <ElipseIconBlue className={cn('alertIcon')} /> : null}
+          {completedCount ? (
+            <ElipseIconGray className={cn('alertIcon')} />
+          ) : pendingCount || confirmedCount ? (
+            <ElipseIconBlue className={cn('alertIcon')} />
+          ) : null}
         </div>
         <div className={cn('chips')}>
           {completedCount ? (
-            <Chips className={cn('chip')} type="confirmed">
+            <Chips className={cn('chip')} type="complete">
               완료 {completedCount}
             </Chips>
-          ) : null}
-          {pendingCount ? (
+          ) : pendingCount ? (
             <Chips className={cn('chip')} type="reservation">
               예약 {pendingCount}
             </Chips>
-          ) : null}
-          {confirmedCount ? (
-            <Chips className={cn('chip')} type="complete">
+          ) : confirmedCount ? (
+            <Chips className={cn('chip')} type="confirmed">
               승인 {confirmedCount}
             </Chips>
           ) : null}

--- a/src/pageLayouts/ReservationCalendarLayout/components/CreateCalendar/CreateCalendar.tsx
+++ b/src/pageLayouts/ReservationCalendarLayout/components/CreateCalendar/CreateCalendar.tsx
@@ -8,39 +8,59 @@ import ElipseIconBlue from '@/images/icon/icon_ellipse_blue.svg';
 
 const cn = classNames.bind(styles);
 
+interface CalendarData {
+  activity: {
+    id: number;
+    title: string;
+  };
+  date: string;
+  endTime: string;
+  headCount: number;
+  id: number;
+  reviewSubmitted: false;
+  scheduleId: number;
+  startTime: string;
+  status: 'declined' | 'confirmed' | 'pending';
+  totalPrice: number;
+  userId: number;
+}
+
 interface CreateCalendarProps {
   currentMonth: dayjs.Dayjs;
   endOfMonth: dayjs.Dayjs;
   startOfMonth: dayjs.Dayjs;
-  completeCount?: number;
-  reservationCount?: number;
-  confirmedCount?: number;
+  data: CalendarData[] | null;
 }
 
-export default function CreateCalendar({
-  currentMonth,
-  endOfMonth,
-  startOfMonth,
-  completeCount = 0,
-  reservationCount = 0,
-  confirmedCount = 0,
-}: CreateCalendarProps) {
-  const RenderAlertIcon = () => {
-    if (reservationCount || confirmedCount || completeCount) {
-      return reservationCount || confirmedCount ? (
-        <ElipseIconBlue className={cn('alertIcon')} />
-      ) : (
-        <ElipseIconGray className={cn('alertIcon')} />
-      );
-    }
-    return null;
-  };
+export default function CreateCalendar({ currentMonth, endOfMonth, startOfMonth, data }: CreateCalendarProps) {
+  console.log(data);
 
   return (
     <div className={cn('itemsWrapper')}>
       {[...Array(endOfMonth.diff(startOfMonth, 'day') + 1)].map((_, i) => {
         const day = startOfMonth.add(i, 'day');
         if (day.month() === currentMonth.month()) {
+          const dayCompleteCount = data?.filter(
+            (item) => item.status === 'confirmed' && dayjs(item.date).isSame(day, 'day'),
+          ).length;
+          const dayReservationCount = data?.filter(
+            (item) => item.status === 'pending' && dayjs(item.date).isSame(day, 'day'),
+          ).length;
+          const dayConfirmCount = data?.filter(
+            (item) => item.status === 'confirmed' && dayjs(item.date).isSame(day, 'day'),
+          ).length;
+
+          const RenderAlertIcon = () => {
+            if (dayReservationCount || dayConfirmCount || dayCompleteCount) {
+              return dayReservationCount || dayConfirmCount ? (
+                <ElipseIconBlue className={cn('alertIcon')} />
+              ) : (
+                <ElipseIconGray className={cn('alertIcon')} />
+              );
+            }
+            return null;
+          };
+
           return (
             <div key={day.format('YYYY-MM-DD')} className={cn('item')}>
               <div className={cn('dayWrapper')}>
@@ -48,19 +68,19 @@ export default function CreateCalendar({
                 {RenderAlertIcon()}
               </div>
               <div className={cn('chips')}>
-                {completeCount ? (
+                {dayCompleteCount ? (
                   <Chips className={cn('chip')} type="confirmed">
-                    완료 {completeCount}
+                    완료 {dayCompleteCount}
                   </Chips>
                 ) : null}
-                {reservationCount ? (
+                {dayReservationCount ? (
                   <Chips className={cn('chip')} type="reservation">
-                    예약 {reservationCount}
+                    예약 {dayReservationCount}
                   </Chips>
                 ) : null}
-                {confirmedCount ? (
+                {dayConfirmCount ? (
                   <Chips className={cn('chip')} type="complete">
-                    승인 {confirmedCount}
+                    승인 {dayConfirmCount}
                   </Chips>
                 ) : null}
               </div>

--- a/src/pageLayouts/ReservationCalendarLayout/components/CreateCalendar/CreateCalendar.tsx
+++ b/src/pageLayouts/ReservationCalendarLayout/components/CreateCalendar/CreateCalendar.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react';
 import classNames from 'classnames/bind';
 import styles from './CreateCalendar.module.scss';
 import dayjs from 'dayjs';
@@ -12,7 +11,7 @@ const cn = classNames.bind(styles);
 interface dashboardDataProps {
   date: string;
   reservations: {
-    declined: number;
+    completed: number;
     confirmed: number;
     pending: number;
   };
@@ -20,23 +19,19 @@ interface dashboardDataProps {
 
 interface CreateCalendarProps {
   currentMonth: dayjs.Dayjs;
-  dashboardData: dashboardDataProps[];
+  dashboardData: dashboardDataProps[] | undefined;
 }
 
-export default function CreateCalendar({ currentMonth, dashboardData = [] }: CreateCalendarProps) {
-  const [completedCount, setCompletedCount] = useState(0);
+export default function CreateCalendar({ currentMonth, dashboardData }: CreateCalendarProps) {
   const startOfMonth = currentMonth.startOf('month');
   const endOfMonth = currentMonth.endOf('month');
-  console.log(dashboardData);
 
   const days = [...Array(endOfMonth.diff(startOfMonth, 'day') + 1)].map((_, i) => {
     const day = startOfMonth.add(i, 'day');
 
     const dashboardDataForThisDate = dashboardData?.find((d) => d.date === day.format('YYYY-MM-DD'));
 
-    if (dashboardDataForThisDate?.reservations.confirmed && day.isBefore(day)) {
-      setCompletedCount(dashboardDataForThisDate?.reservations.confirmed);
-    }
+    const completedCount = dashboardDataForThisDate?.reservations.completed;
     const pendingCount = dashboardDataForThisDate?.reservations.pending;
     const confirmedCount = dashboardDataForThisDate?.reservations.confirmed;
 

--- a/src/pages/user/reservation-calendar/index.tsx
+++ b/src/pages/user/reservation-calendar/index.tsx
@@ -1,7 +1,9 @@
 import ReservationCalendarLayout from '@/pageLayouts/ReservationCalendarLayout/ReservationCalendarLayout';
-import { useGetReservation } from '@/apis/apiHooks/MyReservations';
+
+import { UseGetMyReservationList } from '@/apis/apiHooks/MyActivities';
 
 export default function ReservationCalendarPage() {
-  const { data } = useGetReservation();
-  return <ReservationCalendarLayout data={data} />;
+  const { data: activityList } = UseGetMyReservationList();
+
+  return <ReservationCalendarLayout activityList={activityList} />;
 }

--- a/src/pages/user/reservation-calendar/index.tsx
+++ b/src/pages/user/reservation-calendar/index.tsx
@@ -1,5 +1,7 @@
 import ReservationCalendarLayout from '@/pageLayouts/ReservationCalendarLayout/ReservationCalendarLayout';
+import { useGetReservation } from '@/apis/apiHooks/MyReservations';
 
 export default function ReservationCalendarPage() {
-  return <ReservationCalendarLayout />;
+  const { data } = useGetReservation();
+  return <ReservationCalendarLayout data={data} />;
 }


### PR DESCRIPTION
## What is the PR? 🔍

<!-- 아래 리스트를 지우고, 작업하게 된 배경을 적어주세요. -->

- 예약 현황 페이지의 기능 구현을 위해

## Changes 📝

<!-- 작업 내용 및 덧붙이고 싶은 내용이 있다면! -->

- [x] 예약 현황 페이지의 캘린더 기능 구현
- [x] 캘린더의 달을 변경하거나 체험을 변경하면, 해당되는 예약 내역을 불러오도록 구현함
- [x] 예약 내역에 따라, 알맞은 아이콘과 chip을 불러오도록 구현함
- [x] dropdown이 index를 전달하도록 수정
- [x] category 디자인 수정 및 index 전달하도록 수정

작업 중인 내용
- [ ] chip을 누르면, 예약 정보 모달창이 뜨게 하는 기능
- [ ] 예약 정보 모달창에 필요한 정보를 전달하고, 버튼을 누르면 api 요청이 실행되는 기능

추가 구현 요소
- [x] ~~카테고리 형태의 버튼에서 완료 | 승인 | 예약 버튼을 띄워서 캘린더를 이동하지 않고도 예약 현황을 확인할 수 있는 기능~~ - 기능 구현 포기(api를 수정하지 않으면 서버에 너무 무리가 가는 방식이라 포기함)
카테고리 버튼을 누르면 예약 정보 창을 띄우는 방식으로 수정할 예정

## Screenshot 📷

<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->


| 기능 |          스크린샷           |
| :--: | :-------------------------: |
| GIF  | <img src = "https://github.com/sprint4-16/global-nomad/assets/149885312/9ac6ab8f-7e04-4c62-b65a-c41c231b582f" width ="650"> |

## To Reviewers 🙏

<!-- 리뷰어에게 주목했으면 하는 점 or 바라는 점을 적어주세요. -->
아직 모달 부분을 작업하지 못했지만 일단 올려봅니다. 자세하게 코드리뷰 해주시면 감사하겠습니다.

## Related Issues 💭

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. 수고했습니다~* -->

- Resolved: #75
